### PR TITLE
MGMT-1695 Support HTTPS transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Currently, the functionality of **connectivity_check** is also bundled in the ag
 * *--text*: Dump the inventory as json to the standard output and exit.
 * *--connectivity*: Perform connectivity check and dump the results as json to the standard output.  The details of the nodes to check the connectivity with are provided as a parameter having json format.
 * *--with-text-logging*: Enable writing the agent logs to /var/log/agent.log. Default is true.
-* *--with-journal-logging*: Enable writing logs to systemd journal. Default is true.   
+* *--with-journal-logging*: Enable writing logs to systemd journal. Default is true.
+* *--insecure*: Skip certificate validation in case of HTTPS transport. Should be used only for testing. Default is false.
+* *--cacert*: Path to a custom CA certificate file in PEM format.
 * *--help*: Provide help message.
 
 ### Packaging

--- a/src/commands/register_node.go
+++ b/src/commands/register_node.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -27,7 +28,12 @@ func createRegisterParams() *installer.RegisterHostParams {
 
 func RegisterHostWithRetry() {
 	for {
-		s := session.New()
+
+		s, err := session.New()
+		if err != nil {
+			logrus.Fatalf("Failed to initialize connection: %e", err)
+		}
+
 		registerResult, err := s.Client().Installer.RegisterHost(s.Context(), createRegisterParams())
 		if err == nil {
 			CurrentHost = registerResult.Payload

--- a/src/commands/step_processor.go
+++ b/src/commands/step_processor.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 
@@ -21,7 +22,11 @@ type stepSession struct {
 }
 
 func newSession() *stepSession {
-	ret := stepSession{*session.New()}
+	invSession, err := session.New()
+	if err != nil {
+		log.Fatalf("Failed to initialize connection: %e", err)
+	}
+	ret := stepSession{*invSession}
 	return &ret
 }
 

--- a/src/config/agent_config.go
+++ b/src/config/agent_config.go
@@ -22,6 +22,8 @@ var GlobalAgentConfig struct {
 	TextLogging        bool
 	AgentVersion       string
 	PullSecretToken    string
+	InsecureConnection bool
+	CACertificatePath  string
 }
 
 func printHelpAndExit() {
@@ -42,6 +44,8 @@ func ProcessArgs() {
 	flag.StringVar(&ret.InventoryImage, "inventory-image", "quay.io/ocpmetal/inventory:latest", "The image of inventory")
 	flag.BoolVar(&ret.JournalLogging, "with-journal-logging", true, "Use journal logging")
 	flag.BoolVar(&ret.TextLogging, "with-text-logging", false, "Output log to file")
+	flag.StringVar(&ret.CACertificatePath, "cacert", "", "Path to custom CA certificate in PEM format")
+	flag.BoolVar(&ret.InsecureConnection, "insecure", false, "Do not validate TLS certificate")
 	h := flag.Bool("help", false, "Help message")
 	flag.Parse()
 	if h != nil && *h {


### PR DESCRIPTION
This PR adds control over the default HTTPS transport by adding `--insecure` option (skip certificate validation) and `--cacert` option (provide a custom root CA certificate as a PEM file).