### PR TITLE
MGMT-2075 API VIP connectivity check command

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -10,4 +10,4 @@ RUN microdnf install \
     # logs_sender
     tar && microdnf update systemd \
     && microdnf clean all
-ADD build/agent build/connectivity_check build/free_addresses build/inventory build/logs_sender build/dhcp_lease_allocate /usr/bin/
+ADD build/agent build/connectivity_check build/free_addresses build/inventory build/logs_sender build/dhcp_lease_allocate build/apivip_check /usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export WIREMOCK_PORT = 8362
 all: build
 
 .PHONY: build clean build-image push subsystem
-build: build-agent build-connectivity_check build-inventory build-free_addresses build-logs_sender build-dhcp_lease_allocate
+build: build-agent build-connectivity_check build-inventory build-free_addresses build-logs_sender build-dhcp_lease_allocate build-apivip_check
 
 build-%: src/$*
 	mkdir -p build

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jaypipes/ghw v0.6.1
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	github.com/openshift/assisted-service v1.0.10-0.20201005124942-defa93e0a45e
+	github.com/openshift/assisted-service v1.0.10-0.20201005211755-352fef154311
 	github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -802,6 +802,8 @@ github.com/openshift/assisted-service v1.0.10-0.20200915104653-13d8e23fc222 h1:H
 github.com/openshift/assisted-service v1.0.10-0.20200915104653-13d8e23fc222/go.mod h1:Fmk7cuyHWMqeixviDBDbPcYHVbxJcE0Sqf5IOYopX/w=
 github.com/openshift/assisted-service v1.0.10-0.20201005124942-defa93e0a45e h1:gVJ0vozdNyVfsShZNLsIEHhIMpykNmB0HjnG/BLqV8Q=
 github.com/openshift/assisted-service v1.0.10-0.20201005124942-defa93e0a45e/go.mod h1:F00O4gNwGay/htLQcVauH99OLsn2C6pNeYxz1hPvtQw=
+github.com/openshift/assisted-service v1.0.10-0.20201005211755-352fef154311 h1:hsmj9N8F+eif1hzTaUbJ2GLWIAV3sEF3qFsvvlflXaI=
+github.com/openshift/assisted-service v1.0.10-0.20201005211755-352fef154311/go.mod h1:oQPhM+uXeOjnx1JOsw9pLhMBEdLR781LGjSyC5bpWXs=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c h1:RAgi0xFIHMpsGmYEXoPyZn3Gjomkj/9aCERcqxJP7mc=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c/go.mod h1:+duukQisb5LU1bMtLalsHZc1wM69D5sH3TuiyvAQhhA=

--- a/src/apivip_check/apivip_check.go
+++ b/src/apivip_check/apivip_check.go
@@ -1,0 +1,74 @@
+package apivip_check
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	WorkerIgnitionPath = "/config/worker"
+)
+
+func CheckAPIConnectivity(checkAPIRequestStr string, log logrus.FieldLogger) (stdout string, stderr string, exitCode int) {
+	var checkAPIRequest models.APIVipConnectivityRequest
+
+	if err := json.Unmarshal([]byte(checkAPIRequestStr), &checkAPIRequest); err != nil {
+		wrapped := errors.Wrap(err, "Error unmarshaling APIVipConnectivityRequest")
+		log.WithError(err).Error(wrapped.Error())
+		return createRepsonse(false), wrapped.Error(), -1
+	}
+
+	if checkAPIRequest.URL == nil {
+		err := errors.New("Missing URL in checkAPIRequest")
+		log.WithError(err).Error(err.Error())
+		return createRepsonse(false), err.Error(), -1
+	}
+	
+	if err := httpDownload(*checkAPIRequest.URL + WorkerIgnitionPath, log); err != nil {
+		wrapped := errors.Wrap(err, "Failed to download worker.ign file")
+		log.WithError(err).Error(wrapped.Error())
+		return createRepsonse(false), wrapped.Error(), -1
+	}
+
+	return createRepsonse(true), "", 0
+}
+
+func createRepsonse(success bool) string {
+	checkAPIResponse := models.APIVipConnectivityResponse{
+		IsSuccess: success,
+	}
+	bytes, err := json.Marshal(checkAPIResponse)
+	if err != nil {
+		return ""
+	}
+	return string(bytes)
+}
+
+func httpDownload(uri string, log logrus.FieldLogger) error {
+    res, err := http.Get(uri)
+    if err != nil {
+		return errors.Wrap(err, "HTTP download failure")
+	}
+	
+    defer res.Body.Close()
+    bytes, err := ioutil.ReadAll(res.Body)
+    if err != nil {
+		return errors.Wrap(err, "File read failure")
+	}
+
+	if len(bytes) == 0 {
+		return errors.New("Empty Ignition file")
+	}
+
+	var js json.RawMessage
+    if err = json.Unmarshal(bytes, &js); err != nil {
+		return errors.Wrap(err, "Error unmarshaling Ignition string")
+	}
+
+    return err
+}

--- a/src/apivip_check/apivip_check_test.go
+++ b/src/apivip_check/apivip_check_test.go
@@ -1,0 +1,96 @@
+package apivip_check
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("API connectivity check test", func() {
+	var log logrus.FieldLogger
+	var srv *httptest.Server
+
+	BeforeEach(func() {
+		log = logrus.New()
+	})
+
+	AfterEach(func() {
+		srv.Close()
+	})
+
+	It("HTTP download ignition file", func() {
+		srv = serverMock(ignitionMock)
+		_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
+		Expect(exitCode).Should(Equal(0))
+	})
+
+	It("Invalid ignition file format", func() {
+		srv = serverMock(ignitionMockInvalid)
+		_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
+		Expect(exitCode).Should(Equal(-1))
+	})
+
+	It("Empty ignition", func() {
+		srv = serverMock(ignitionMockEmpty)
+		_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
+		Expect(exitCode).Should(Equal(-1))
+	})
+
+	It("Invalid API URL", func() {
+		url := "http://127.0.0.1:2345"
+		_, _, exitCode := CheckAPIConnectivity(getRequestStr(&url), log)
+		Expect(exitCode).Should(Equal(-1))
+	})
+
+	It("Missing API URL", func() {
+		_, _, exitCode := CheckAPIConnectivity(getRequestStr(nil), log)
+		Expect(exitCode).Should(Equal(-1))
+	})
+})
+
+func getRequestStr(url *string) string {
+	request := models.APIVipConnectivityRequest{
+		URL: url,
+	}
+
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		return ""
+	}
+	return string(requestBytes)
+}
+
+func serverMock(mock func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	handler := http.NewServeMux()
+	handler.HandleFunc(WorkerIgnitionPath, mock)
+	srv := httptest.NewServer(handler)
+	return srv
+}
+
+func ignitionMock(w http.ResponseWriter, r *http.Request) {
+	ignitionConfig, err := FormatNodeIgnitionFile("http://127.0.0.1:1234")
+	if err != nil {
+		return
+	}
+	_, _ = w.Write([]byte(ignitionConfig))
+}
+
+func ignitionMockInvalid(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte("invalid"))
+}
+
+func ignitionMockEmpty(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write([]byte{})
+}
+
+func TestSubsystem(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "API connectivity check unit tests")
+}

--- a/src/apivip_check/main/main.go
+++ b/src/apivip_check/main/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/openshift/assisted-installer-agent/src/config"
+	"github.com/openshift/assisted-installer-agent/src/util"
+
+	"github.com/openshift/assisted-installer-agent/src/apivip_check"
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	config.ProcessSubprocessArgs(false, true)
+	util.SetLogging("apivip_check", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging)
+	if flag.NArg() != 1 {
+		log.Warnf("Expecting exactly single argument to apivip_check. Received %d", len(os.Args)-1)
+		os.Exit(-1)
+	}
+	stdout, stderr, exitCode := apivip_check.CheckAPIConnectivity(flag.Arg(0), log.StandardLogger())
+	fmt.Fprint(os.Stdout, stdout)
+	fmt.Fprint(os.Stderr, stderr)
+	os.Exit(exitCode)
+}

--- a/src/apivip_check/utils.go
+++ b/src/apivip_check/utils.go
@@ -1,0 +1,33 @@
+package apivip_check
+
+import (
+	"bytes"
+	"text/template"
+)
+
+const nodeIgnitionFormat = `{
+	"ignition": {
+		"version": "3.1.0",
+		"config": {
+			"merge": [{
+				"source": "{{.SOURCE}}"
+			}]
+		}
+	}
+}`
+
+func FormatNodeIgnitionFile(source string) ([]byte, error) {
+	var ignitionParams = map[string]string{
+		"SOURCE": source,
+	}
+	
+	tmpl, err := template.New("nodeIgnition").Parse(nodeIgnitionFormat)
+	if err != nil {
+		return nil, err
+	}
+	buf := &bytes.Buffer{}
+	if err = tmpl.Execute(buf, ignitionParams); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/subsystem/apivip_check_test.go
+++ b/subsystem/apivip_check_test.go
@@ -1,0 +1,104 @@
+package subsystem
+
+import (
+	"encoding/json"
+	"time"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	
+	"github.com/openshift/assisted-installer-agent/src/apivip_check"
+	"github.com/openshift/assisted-service/models"
+)
+
+const (
+	stepAPIConnectivityID = "apivip-connectivity-check-step"
+)
+
+var _ = Describe("API VIP connectivity check tests", func() {
+	var (
+		hostID     string
+	)
+
+	BeforeEach(func() {
+		resetAll()
+		hostID = nextHostID()
+	})
+
+	It("verify API connectivity", func() {
+		url := "http://127.0.0.1:8362"
+		setWorkerIgnitionStub(hostID, &models.APIVipConnectivityRequest{
+			URL: &url,
+		})
+		setReplyStartAgent(hostID)
+
+		Eventually(func() bool {
+			return isReplyFound(hostID, &APIConnectivityCheckVerifier{})
+		}, 300*time.Second, 5*time.Second).Should(BeTrue())
+	})
+})
+
+func setWorkerIgnitionStub(hostID string, request *models.APIVipConnectivityRequest) {
+	_, err := addRegisterStub(hostID, http.StatusCreated)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = addWorkerIgnitionStub()
+	Expect(err).NotTo(HaveOccurred())
+
+	b, err := json.Marshal(&request)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	_, err = addNextStepStub(hostID, 5,
+		&models.Step{
+			StepType: models.StepTypeAPIVipConnectivityCheck,
+			StepID:   stepAPIConnectivityID,
+			Command:  "docker",
+			Args: []string{
+				"run", "--privileged", "--net=host", "--rm",
+				"-v", "/var/log:/var/log",
+				"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
+				"quay.io/derez/assisted-installer-agent:test",
+				"apivip_check",
+				string(b),
+			},
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+type APIConnectivityCheckVerifier struct{}
+
+func (i *APIConnectivityCheckVerifier) verify(actualReply *models.StepReply) bool {
+	if actualReply.ExitCode != 0 {
+		log.Errorf("APIConnectivityCheckVerifier returned with exit code %d. error: %s", actualReply.ExitCode, actualReply.Error)
+		return false
+	}
+	if actualReply.StepType != models.StepTypeAPIVipConnectivityCheck {
+		log.Errorf("APIConnectivityCheckVerifier invalid step replay %s", actualReply.StepType)
+		return false
+	}
+
+	return int(actualReply.ExitCode) == 0
+}
+
+func addWorkerIgnitionStub() (string, error) {
+	ignitionConfig, err := apivip_check.FormatNodeIgnitionFile(WireMockURL + apivip_check.WorkerIgnitionPath)
+	if err != nil {
+		return "", err
+	}
+	stub := StubDefinition{
+		Request: &RequestDefinition{
+			URL:    apivip_check.WorkerIgnitionPath,
+			Method: "GET",
+		},
+		Response: &ResponseDefinition{
+			Status: 200,
+			Body:   string(ignitionConfig),
+			Headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+	}
+	return addStub(&stub)
+}


### PR DESCRIPTION
* Added apivip_check command:
- For ensuring connectivity between the node to and the API.
- Done by invoking a GET request to <api>/config/worker (to download the worker.ign file).

* Added relevant tests with wiremock stubs in subsystem/apivip_check_test.