### PR TITLE
MGMT-2318 added network CIDR verification to API VIP check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jaypipes/ghw v0.6.1
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	github.com/openshift/assisted-service v1.0.10-0.20201005211755-352fef154311
+	github.com/openshift/assisted-service v1.0.10-0.20201011075418-f8bc63cfc5e8
 	github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -654,6 +654,7 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -826,6 +827,8 @@ github.com/openshift/assisted-service v1.0.10-0.20201005124942-defa93e0a45e h1:g
 github.com/openshift/assisted-service v1.0.10-0.20201005124942-defa93e0a45e/go.mod h1:F00O4gNwGay/htLQcVauH99OLsn2C6pNeYxz1hPvtQw=
 github.com/openshift/assisted-service v1.0.10-0.20201005211755-352fef154311 h1:hsmj9N8F+eif1hzTaUbJ2GLWIAV3sEF3qFsvvlflXaI=
 github.com/openshift/assisted-service v1.0.10-0.20201005211755-352fef154311/go.mod h1:oQPhM+uXeOjnx1JOsw9pLhMBEdLR781LGjSyC5bpWXs=
+github.com/openshift/assisted-service v1.0.10-0.20201011075418-f8bc63cfc5e8 h1:DxJxAIEDS/R2uVPZz6UFJdCnCPb8N5Rav/iiY3uvA14=
+github.com/openshift/assisted-service v1.0.10-0.20201011075418-f8bc63cfc5e8/go.mod h1:CKT0cnC9Kp59V5xSBqyuL8/QJXPXpzcr6CPlvWiHs4I=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c h1:RAgi0xFIHMpsGmYEXoPyZn3Gjomkj/9aCERcqxJP7mc=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c/go.mod h1:+duukQisb5LU1bMtLalsHZc1wM69D5sH3TuiyvAQhhA=

--- a/src/apivip_check/apivip_check.go
+++ b/src/apivip_check/apivip_check.go
@@ -3,7 +3,9 @@ package apivip_check
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"net/url"
 
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
@@ -29,10 +31,18 @@ func CheckAPIConnectivity(checkAPIRequestStr string, log logrus.FieldLogger) (st
 		return createRepsonse(false), err.Error(), -1
 	}
 	
-	if err := httpDownload(*checkAPIRequest.URL + WorkerIgnitionPath, log); err != nil {
+	if err := httpDownload(*checkAPIRequest.URL + WorkerIgnitionPath); err != nil {
 		wrapped := errors.Wrap(err, "Failed to download worker.ign file")
 		log.WithError(err).Error(wrapped.Error())
 		return createRepsonse(false), wrapped.Error(), -1
+	}
+
+	if checkAPIRequest.VerifyCidr {
+		if err := verifyCIDR(*checkAPIRequest.URL); err != nil {
+			wrapped := errors.Wrap(err, "CheckAPIConnectivity: failure verifying CIDR of API VIP")
+			log.WithError(err).Error(wrapped.Error())
+			return createRepsonse(false), wrapped.Error(), -1
+		}
 	}
 
 	return createRepsonse(true), "", 0
@@ -49,7 +59,7 @@ func createRepsonse(success bool) string {
 	return string(bytes)
 }
 
-func httpDownload(uri string, log logrus.FieldLogger) error {
+func httpDownload(uri string) error {
     res, err := http.Get(uri)
     if err != nil {
 		return errors.Wrap(err, "HTTP download failure")
@@ -65,10 +75,64 @@ func httpDownload(uri string, log logrus.FieldLogger) error {
 		return errors.New("Empty Ignition file")
 	}
 
-	var js json.RawMessage
+    var js json.RawMessage
     if err = json.Unmarshal(bytes, &js); err != nil {
 		return errors.Wrap(err, "Error unmarshaling Ignition string")
 	}
 
     return err
+}
+
+func verifyCIDR(uri string) error {
+	apiVip, err := getIPByURI(uri)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get VIP API")
+	}
+
+	_, err = calculateMachineNetworkCIDR(apiVip)
+	if err != nil {
+		return errors.Wrap(err, "Failed to calculate network CIDR")
+	}
+
+	return nil
+}
+
+func getIPByURI(uri string) (net.IP, error) {
+	u, err := url.Parse(uri)
+    if err != nil {
+		return nil, errors.Wrap(err, "Failed parsing specified URL")
+	}
+	
+	host, _, _ := net.SplitHostPort(u.Host)
+	if ip := net.ParseIP(host); ip != nil {
+		return ip, nil
+	}
+
+	addr, err := net.LookupIP(host)
+	if err != nil {
+	   return nil, errors.Wrap(err, "Unknown host for specified API VIP")
+	}
+	return addr[0], nil
+}
+
+func calculateMachineNetworkCIDR(apiVip net.IP) (string, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to fetch machine's interfaces")
+	}
+
+	for _, intf := range interfaces {
+		addrs, _ := intf.Addrs()
+		for _, ipv4addr := range addrs {
+			_, ipnet, err := net.ParseCIDR(ipv4addr.String())
+			if err != nil {
+				continue
+			}
+			if ipnet.Contains(apiVip) {
+				return ipnet.String(), nil
+			}
+		}
+	}
+
+	return "", errors.Errorf("No suitable matching CIDR found for API VIP %s", apiVip)
 }

--- a/src/apivip_check/apivip_check_test.go
+++ b/src/apivip_check/apivip_check_test.go
@@ -25,39 +25,68 @@ var _ = Describe("API connectivity check test", func() {
 		srv.Close()
 	})
 
-	It("HTTP download ignition file", func() {
-		srv = serverMock(ignitionMock)
-		_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
-		Expect(exitCode).Should(Equal(0))
+	Context("Ignition file", func() {
+		It("Download ignition file successfully", func() {
+			srv = serverMock(ignitionMock)
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false), log)
+			Expect(exitCode).Should(Equal(0))
+		})
+
+		It("Invalid ignition file format", func() {
+			srv = serverMock(ignitionMockInvalid)
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false), log)
+			Expect(exitCode).Should(Equal(-1))
+		})
+
+		It("Empty ignition", func() {
+			srv = serverMock(ignitionMockEmpty)
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false), log)
+			Expect(exitCode).Should(Equal(-1))
+		})
 	})
 
-	It("Invalid ignition file format", func() {
-		srv = serverMock(ignitionMockInvalid)
-		_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
-		Expect(exitCode).Should(Equal(-1))
+	Context("API URL", func() {
+		It("Invalid API URL", func() {
+			url := "http://127.0.0.1:2345"
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&url, false), log)
+			Expect(exitCode).Should(Equal(-1))
+		})
+
+		It("Missing API URL", func() {
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(nil, false), log)
+			Expect(exitCode).Should(Equal(-1))
+		})
 	})
 
-	It("Empty ignition", func() {
-		srv = serverMock(ignitionMockEmpty)
-		_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
-		Expect(exitCode).Should(Equal(-1))
-	})
+	Context("Verify CIDR", func() {
+		It("Verification success - hostname", func() {
+			srv = serverMock(ignitionMock)
+			err := verifyCIDR("http://localhost:1234")
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-	It("Invalid API URL", func() {
-		url := "http://127.0.0.1:2345"
-		_, _, exitCode := CheckAPIConnectivity(getRequestStr(&url), log)
-		Expect(exitCode).Should(Equal(-1))
-	})
+		It("Verification success - IP address", func() {
+			srv = serverMock(ignitionMock)
+			err := verifyCIDR("http://127.0.0.1:1234")
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-	It("Missing API URL", func() {
-		_, _, exitCode := CheckAPIConnectivity(getRequestStr(nil), log)
-		Expect(exitCode).Should(Equal(-1))
+		It("Invalid URL", func() {
+			err := verifyCIDR("http://invalid:1234")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("CIDR not suitable", func() {
+			err := verifyCIDR("http://example.com:1234")
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })
 
-func getRequestStr(url *string) string {
+func getRequestStr(url *string, verifyCidr bool) string {
 	request := models.APIVipConnectivityRequest{
 		URL: url,
+		VerifyCidr: verifyCidr,
 	}
 
 	requestBytes, err := json.Marshal(request)

--- a/subsystem/apivip_check_test.go
+++ b/subsystem/apivip_check_test.go
@@ -58,7 +58,7 @@ func setWorkerIgnitionStub(hostID string, request *models.APIVipConnectivityRequ
 				"run", "--privileged", "--net=host", "--rm",
 				"-v", "/var/log:/var/log",
 				"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
-				"quay.io/derez/assisted-installer-agent:test",
+				"quay.io/ocpmetal/assisted-installer-agent:latest",
 				"apivip_check",
 				string(b),
 			},


### PR DESCRIPTION
Added network CIDR verification to API VIP connectivity check:
- Parse IP from API VIP.
- Get interfaces of the node.
- Calculate CIDRs by interfaces.
- API is verified if contained in one of the CIDRs.