### PR TITLE
[WIP] Use centos image rather than fedora

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -1,5 +1,5 @@
-FROM registry.fedoraproject.org/fedora-minimal:31
-RUN microdnf install \
+FROM quay.io/app-sre/centos:8
+RUN dnf -y install \
     kmod findutils iputils \
     # inventory
     dmidecode ipmitool lshw biosdevname \
@@ -8,6 +8,6 @@ RUN microdnf install \
     # dhcp_lease_allocate
     dhclient \
     # logs_sender
-    tar && microdnf update systemd \
-    && microdnf clean all
+    tar && dnf -y update systemd \
+    && dnf -y clean all
 ADD build/agent build/connectivity_check build/free_addresses build/inventory build/logs_sender build/dhcp_lease_allocate build/apivip_check /usr/bin/

--- a/subsystem/Dockerfile.agent_test
+++ b/subsystem/Dockerfile.agent_test
@@ -1,2 +1,3 @@
 FROM quay.io/ocpmetal/assisted-installer-agent:latest
-RUN microdnf install docker && microdnf clean all
+RUN curl --output /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/centos/docker-ce.repo
+RUN dnf install -y docker-ce docker-ce-cli containerd.io && dnf -y clean all


### PR DESCRIPTION
This should fix the compatibility problems with systemd libs

Previously we got a new version of the fedora image and it was failing
to collect logs with the following error:

`Output Failed to run send logs journalctl: error while loading shared libraries: libsystemd-shared-245.so: cannot open shared object file: No such file or directory`

This seems to be because the version of systemd is much newer on the
fedora container than it is on the RHCOS host