### PR TITLE
OCPBUGSM-19005 add log with StepId

### DIFF
--- a/src/commands/step_processor.go
+++ b/src/commands/step_processor.go
@@ -64,6 +64,7 @@ func (s *stepSession) sendStepReply(stepType models.StepType, stepID, output, er
 }
 
 func (s *stepSession) handleSingleStep(stepType models.StepType, stepID string, command string, args []string, handler HandlerType) {
+	s.Logger().Infof("Executing step: <%s>, command: <%s>, args: <%v>", stepID, command, args)
 	stdout, stderr, exitCode := handler(command, args...)
 	s.sendStepReply(stepType, stepID, stdout, stderr, exitCode)
 }


### PR DESCRIPTION
Adding log for better debug abilities.

`Oct 13 11:29:24 test-infra-cluster-assisted-installer-master-1 agent[1782]: time="13-10-2020 11:29:24" level=info msg="Executing step: <dhcp-lease-allocate-65af5fd9>, command: <podman>, args: <[run --privileged --net=host --rm --quiet -v /var/log:/var/log -v /run/systemd/journal/socket:/run/systemd/journal/socket quay.io/ocpmetal/assisted-installer-agent:latest dhcp_lease_allocate {\"api_vip_mac\":\"00:1a:4a:94:cc:16\",\"ingress_vip_mac\":\"00:1a:4a:b8:f7:25\",\"interface\":\"ens3\"}]>" file="step_processor.go:67" request_id=747ae4db-1f73-4014-83b6-cca6ef2e3bd0`

`Oct 13 11:29:24 test-infra-cluster-assisted-installer-master-1 agent[1782]: time="13-10-2020 11:29:24" level=info msg="Executing step: <install-6325892d>, command: <bash>, args: <[-c podman run -v /dev:/dev:rw -v /opt:/opt:rw -v /run/systemd/journal/socket:/run/systemd/journal/socket --privileged --pid=host --net=host -v /var/log:/var/log:rw --env PULL_SECRET_TOKEN --name assisted-installer quay.io/ocpmetal/assisted-installer:latest --role master --cluster-id 5e22b277-4e28-42bd-8261-7ef49f884acf --boot-device /dev/vda --host-id 0865ccdd-9639-4488-b506-7477416b8dfc --openshift-version 4.6 --controller-image quay.io/ocpmetal/assisted-installer-controller:latest --url http://10.1.37.42:6000 --insecure=true --agent-image quay.io/ocpmetal/assisted-installer-agent:latest --host-name test-infra-cluster-assisted-installer-master-1]>" file="step_processor.go:67" request_id=747ae4db-1f73-4014-83b6-cca6ef2e3bd0`


`Oct 12 14:26:08 test-infra-cluster-assisted-installer-master-1 agent[1782]: time="12-10-2020 14:26:08" level=info msg="Executing step <free-network-addresses-9e255669>" file="step_processor.go:67" request_id=382901bf-e523-4775-804b-20e159e33327`