### PR TITLE
MGMT-2431: Adding 'installer-gather.sh' to logs_sender on failure.

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -5,6 +5,7 @@ RUN apt-get update ; apt-get install -y docker.io docker-compose
 RUN go get -u golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
               github.com/onsi/ginkgo/ginkgo@v1.12.2  \
               github.com/golang/mock/mockgen@v1.4.3  \
+              github.com/vektra/mockery/.../@v1.1.2 \
               gotest.tools/gotestsum@v0.5.3 \
               github.com/axw/gocov/gocov \
               github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/swag v0.19.9
-	github.com/golang/mock v1.4.4 // indirect
+	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.1.1
 	github.com/jaypipes/ghw v0.6.1
 	github.com/onsi/ginkgo v1.14.0
@@ -16,6 +16,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/ssgreg/journald v1.0.0
 	github.com/stretchr/testify v1.6.1
+	github.com/vektra/mockery v1.1.2 // indirect
 	github.com/vishvananda/netlink v1.1.0
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1035,6 +1035,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
+github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
@@ -1385,6 +1387,7 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200430192856-2840dafb9ee1/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/src/config/logs_sender_config.go
+++ b/src/config/logs_sender_config.go
@@ -7,21 +7,22 @@ import (
 )
 
 var LogsSenderConfig struct {
-	TextLogging     bool
-	JournalLogging  bool
-	Tags            []string
-	Services        []string
-	Since           string
-	HostID          string
-	ClusterID       string
-	CleanWhenDone   bool
-	TargetURL       string
-	PullSecretToken string
+	TextLogging            bool
+	JournalLogging         bool
+	Tags                   []string
+	Services               []string
+	Since                  string
+	HostID                 string
+	ClusterID              string
+	CleanWhenDone          bool
+	TargetURL              string
+	PullSecretToken        string
+	IsBootstrap            bool
+	InstallerGatherlogging bool
 }
 
 func ProcessLogsSenderConfigArgs(defaultTextLogging, defaultJournalLogging bool) {
 	var leaveFiles bool
-	var boostrap bool
 	flag.BoolVar(&LogsSenderConfig.JournalLogging, "with-journal-logging", defaultJournalLogging, "Use journal logging")
 	flag.BoolVar(&LogsSenderConfig.TextLogging, "with-text-logging", defaultTextLogging, "Use text logging")
 	flag.StringVar(&LogsSenderConfig.Since, "since", "5 hours ago", "Journalctl since flag, same format")
@@ -30,7 +31,8 @@ func ProcessLogsSenderConfigArgs(defaultTextLogging, defaultJournalLogging bool)
 	flag.StringVar(&LogsSenderConfig.HostID, "host-id", "host-id", "The value of the host-id")
 	flag.StringVar(&LogsSenderConfig.PullSecretToken, "pull-secret-token", "", "Pull secret token")
 	flag.BoolVar(&leaveFiles, "dont-clean", false, "Don't delete all created files on finish. Required")
-	flag.BoolVar(&boostrap, "bootstrap", false, "Gather and send logs on bootstrap node")
+	flag.BoolVar(&LogsSenderConfig.IsBootstrap, "bootstrap", false, "Gather and send logs on bootstrap node")
+	flag.BoolVar(&LogsSenderConfig.InstallerGatherlogging, "with-installer-gather-logging", false, "Use installer-gather logging")
 	flag.StringVar(&GlobalAgentConfig.CACertificatePath, "cacert", "", "Path to custom CA certificate in PEM format")
 	flag.BoolVar(&GlobalAgentConfig.InsecureConnection, "insecure", false, "Do not validate TLS certificate")
 	h := flag.Bool("help", false, "Help message")
@@ -54,7 +56,7 @@ func ProcessLogsSenderConfigArgs(defaultTextLogging, defaultJournalLogging bool)
 	}
 
 	LogsSenderConfig.Tags = []string{"agent", "installer"}
-	if boostrap {
+	if LogsSenderConfig.IsBootstrap {
 		LogsSenderConfig.Services = []string{"bootkube"}
 	}
 

--- a/src/logs_sender/mock_LogsSender.go
+++ b/src/logs_sender/mock_LogsSender.go
@@ -89,6 +89,41 @@ func (_m *MockLogsSender) ExecuteOutputToFile(outputFilePath string, command str
 	return r0, r1
 }
 
+// ExecutePrivilege provides a mock function with given fields: command, args
+func (_m *MockLogsSender) ExecutePrivilege(command string, args ...string) (string, string, int) {
+	_va := make([]interface{}, len(args))
+	for _i := range args {
+		_va[_i] = args[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, command)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, ...string) string); ok {
+		r0 = rf(command, args...)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 string
+	if rf, ok := ret.Get(1).(func(string, ...string) string); ok {
+		r1 = rf(command, args...)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	var r2 int
+	if rf, ok := ret.Get(2).(func(string, ...string) int); ok {
+		r2 = rf(command, args...)
+	} else {
+		r2 = ret.Get(2).(int)
+	}
+
+	return r0, r1, r2
+}
+
 // FileUploader provides a mock function with given fields: filePath, clusterID, hostID, inventoryUrl, pullSecretToken, agentVersion
 func (_m *MockLogsSender) FileUploader(filePath string, clusterID strfmt.UUID, hostID strfmt.UUID, inventoryUrl string, pullSecretToken string, agentVersion string) error {
 	ret := _m.Called(filePath, clusterID, hostID, inventoryUrl, pullSecretToken, agentVersion)

--- a/src/logs_sender/send_logs_test.go
+++ b/src/logs_sender/send_logs_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/go-openapi/strfmt"
+	strfmt "github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -100,13 +100,17 @@ var _ = Describe("logs sender", func() {
 	})
 
 	It("Upload failed", func() {
-
 		folderSuccess()
 		executeOutputToFileSuccess()
 		archiveSuccess()
+		config.LogsSenderConfig.IsBootstrap = true
+		config.LogsSenderConfig.InstallerGatherlogging = true
+		logsSenderMock.On("ExecutePrivilege", "/usr/local/bin/installer-gather.sh").Return("Dummy", "", 0)
+		logsSenderMock.On("ExecutePrivilege", "mv", "/root/log-bundle-.tar.gz", fmt.Sprintf("%s/installer_gather.tar.gz", logsTmpFilesDir)).Return("Dummy", "", 0)
 		logsSenderMock.On("FileUploader", archivePath, strfmt.UUID(config.LogsSenderConfig.ClusterID),
 			strfmt.UUID(config.LogsSenderConfig.HostID), config.LogsSenderConfig.TargetURL, config.LogsSenderConfig.PullSecretToken, config.GlobalAgentConfig.AgentVersion).
 			Return(errors.Errorf("Dummy"))
+
 		err := SendLogs(logsSenderMock)
 		fmt.Println(err)
 		Expect(err).To(HaveOccurred())
@@ -117,6 +121,10 @@ var _ = Describe("logs sender", func() {
 		folderSuccess()
 		executeOutputToFileSuccess()
 		archiveSuccess()
+		config.LogsSenderConfig.IsBootstrap = true
+		config.LogsSenderConfig.InstallerGatherlogging = true
+		logsSenderMock.On("ExecutePrivilege", "/usr/local/bin/installer-gather.sh").Return("Dummy", "", 0)
+		logsSenderMock.On("ExecutePrivilege", "mv", "/root/log-bundle-.tar.gz", fmt.Sprintf("%s/installer_gather.tar.gz", logsTmpFilesDir)).Return("Dummy", "", 0)
 		logsSenderMock.On("FileUploader", archivePath, strfmt.UUID(config.LogsSenderConfig.ClusterID),
 			strfmt.UUID(config.LogsSenderConfig.HostID), config.LogsSenderConfig.TargetURL, config.LogsSenderConfig.PullSecretToken, config.GlobalAgentConfig.AgentVersion).
 			Return(nil)


### PR DESCRIPTION
We will now also send to `assisted-service` `installer-gather.sh` logs
on cluster installation cancel of error.

In case the installation succeed, those logs won't be sent, it is
parametrized and can be changed.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>