### PR TITLE
MGMT-2440 Fix the errors in inventory when trying to get BMC information

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -1,6 +1,6 @@
 FROM quay.io/app-sre/centos:8
 RUN dnf install -y \
-    	kmod findutils iputils \
+    	findutils iputils \
         podman \
     	# inventory
     	dmidecode ipmitool lshw biosdevname file \

--- a/src/inventory/bmc.go
+++ b/src/inventory/bmc.go
@@ -1,13 +1,10 @@
 package inventory
 
 import (
-	"fmt"
 	"net"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/sirupsen/logrus"
 
 	"gopkg.in/yaml.v2"
 )
@@ -20,21 +17,6 @@ type bmc struct {
 
 func newBMC(dependencies IDependencies) *bmc {
 	return &bmc{dependicies: dependencies}
-}
-
-func (b *bmc) modprobe(module string) error {
-	_, stderr, exitCode := b.dependicies.Execute("modprobe", module)
-	if exitCode != 0 {
-		logrus.Warnf("Could not modprobe module %s: %s", module, stderr)
-		return fmt.Errorf("Could not modprobe module %s: %s", module, stderr)
-	}
-	return nil
-}
-
-func (b *bmc) loadModules() {
-	_ = b.modprobe("ipmi_msghandler")
-	_ = b.modprobe("ipmi_devintf")
-	_ = b.modprobe("ipmi_si")
 }
 
 func (b *bmc) getIpForChannnel(ch int) string {
@@ -57,7 +39,6 @@ func (b *bmc) getIsEnabled(value interface{}) bool {
 }
 
 func (b *bmc) getBmcAddress() string {
-	b.loadModules()
 	for ch := 1; ch <= MaxIpmiChannel; ch++ {
 		ret := b.getIpForChannnel(ch)
 		if ret == "" {
@@ -138,7 +119,6 @@ func (b *bmc) getAddrMode(ch int) string {
 }
 
 func (b *bmc) getBmcV6Address() string {
-	b.loadModules()
 	for ch := 1; ch <= MaxIpmiChannel; ch++ {
 		addrMode := b.getAddrMode(ch)
 		if addrMode == "" {

--- a/src/inventory/bmc_test.go
+++ b/src/inventory/bmc_test.go
@@ -250,9 +250,6 @@ var _ = Describe("bmc", func() {
 
 	BeforeEach(func() {
 		dependencies = newDependenciesMock()
-		dependencies.On("Execute", "modprobe", "ipmi_msghandler").Return("", "", 0).Once()
-		dependencies.On("Execute", "modprobe", "ipmi_devintf").Return("", "", 0).Once()
-		dependencies.On("Execute", "modprobe", "ipmi_si").Return("", "", 0).Once()
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
- Loading kernel modules in a container is meaningless and produces errors in logs - so it was removed
/cc @ronniel1 
/cc @tsorya 