### PR TITLE
NO-ISSUE: Configuring privilege command to run using host network namespace.

### DIFF
--- a/src/logs_sender/send_logs.go
+++ b/src/logs_sender/send_logs.go
@@ -36,7 +36,7 @@ func (e *LogsSenderExecuter) Execute(command string, args ...string) (stdout str
 // ExecutePrivilege execute a command in the host environment via nsenter
 func (e *LogsSenderExecuter) ExecutePrivilege(command string, args ...string) (stdout string, stderr string, exitCode int) {
 	commandBase := "nsenter"
-	arguments := []string{"-t", "1", "-m", "-i", "--", command}
+	arguments := []string{"-t", "1", "-m", "-i", "-n", "--", command}
 	arguments = append(arguments, args...)
 	return e.Execute(commandBase, arguments...)
 }


### PR DESCRIPTION
`oc` command is used in `installer-gather.sh` and it need to have access
to Openshift API server.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>