### PR TITLE
MGMT-2678: Supplying masters host names to installer-gather.sh.

### DIFF
--- a/src/config/logs_sender_config.go
+++ b/src/config/logs_sender_config.go
@@ -19,6 +19,7 @@ var LogsSenderConfig struct {
 	PullSecretToken        string
 	IsBootstrap            bool
 	InstallerGatherlogging bool
+	MastersIPs             string
 }
 
 func ProcessLogsSenderConfigArgs(defaultTextLogging, defaultJournalLogging bool) {
@@ -35,6 +36,7 @@ func ProcessLogsSenderConfigArgs(defaultTextLogging, defaultJournalLogging bool)
 	flag.BoolVar(&LogsSenderConfig.InstallerGatherlogging, "with-installer-gather-logging", false, "Use installer-gather logging")
 	flag.StringVar(&GlobalAgentConfig.CACertificatePath, "cacert", "", "Path to custom CA certificate in PEM format")
 	flag.BoolVar(&GlobalAgentConfig.InsecureConnection, "insecure", false, "Do not validate TLS certificate")
+	flag.StringVar(&LogsSenderConfig.MastersIPs, "masters-ips", "", "list of ',' separated IPs of all masters nodes in the cluster for SSH use")
 	h := flag.Bool("help", false, "Help message")
 
 	flag.Parse()

--- a/src/logs_sender/mock_LogsSender.go
+++ b/src/logs_sender/mock_LogsSender.go
@@ -89,8 +89,8 @@ func (_m *MockLogsSender) ExecuteOutputToFile(outputFilePath string, command str
 	return r0, r1
 }
 
-// ExecutePrivilege provides a mock function with given fields: command, args
-func (_m *MockLogsSender) ExecutePrivilege(command string, args ...string) (string, string, int) {
+// ExecutePrivileged provides a mock function with given fields: command, args
+func (_m *MockLogsSender) ExecutePrivileged(command string, args ...string) (string, string, int) {
 	_va := make([]interface{}, len(args))
 	for _i := range args {
 		_va[_i] = args[_i]
@@ -131,6 +131,20 @@ func (_m *MockLogsSender) FileUploader(filePath string, clusterID strfmt.UUID, h
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string, strfmt.UUID, strfmt.UUID, string, string, string) error); ok {
 		r0 = rf(filePath, clusterID, hostID, inventoryUrl, pullSecretToken, agentVersion)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// GatherInstallerLogs provides a mock function with given fields: targetDir
+func (_m *MockLogsSender) GatherInstallerLogs(targetDir string) error {
+	ret := _m.Called(targetDir)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(targetDir)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/src/util/execute.go
+++ b/src/util/execute.go
@@ -61,7 +61,7 @@ func ExecuteShell(command string) (stdout string, stderr string, exitCode int) {
 
 func ExecutePrivileged(command string, args ...string) (stdout string, stderr string, exitCode int) {
 	commandBase := "nsenter"
-	arguments := []string{"-t", "1", "-m", "-i", "--", command}
+	arguments := []string{"-t", "1", "-m", "-i", "-n", "--", command}
 	arguments = append(arguments, args...)
 	return Execute(commandBase, arguments...)
 }


### PR DESCRIPTION
If not supplied, `installer-gather.sh` will try to get this information
using `oc get nodes` but the use case we are trying to get logs for is
the one in which part of the masters didn't join the cluster so `oc get
nods` won't work.

Masters host names are retrieved from `assisted-service` API.

Also added gatherID to the log-bundle created.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>