### PR TITLE
OCPBUGSM-19005 - Print step output after step execution fails

### DIFF
--- a/src/commands/step_processor.go
+++ b/src/commands/step_processor.go
@@ -77,6 +77,15 @@ func (s *stepSession) sendStepReply(stepType models.StepType, stepID, output, er
 func (s *stepSession) handleSingleStep(stepType models.StepType, stepID string, command string, args []string, handler HandlerType) {
 	s.Logger().Infof("Executing step: <%s>, command: <%s>, args: <%v>", stepID, command, args)
 	stdout, stderr, exitCode := handler(command, args...)
+	if exitCode != 0 {
+		s.Logger().Infof(`Step execution failed (exit code %v): <%s>, command: <%s>, args: <%v>. Output:
+stdout:
+%v
+
+stderr:
+%v
+`, exitCode, stepID, command, args, stdout, stderr)
+	}
 	s.sendStepReply(stepType, stepID, stdout, stderr, exitCode)
 }
 


### PR DESCRIPTION
We want step executoin failures to show up on the agent log and not just the service log.