### PR TITLE
MGMT-3033 - Populating S.M.A.R.T. field in inventory host disks

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -3,7 +3,7 @@ RUN dnf install -y \
 		findutils iputils \
 		podman \
 		# inventory
-		dmidecode ipmitool biosdevname file \
+		smartmontools dmidecode ipmitool biosdevname file \
 		# free_addresses
 		nmap \
 		# dhcp_lease_allocate

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jaypipes/ghw v0.6.1
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
-	github.com/openshift/assisted-service v1.0.10-0.20201117161456-e97b039ef0c0
+	github.com/openshift/assisted-service v1.0.10-0.20201123173047-fc89b94631c2
 	github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -874,6 +874,8 @@ github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87/go.mod h1:fT6U/JfG8u
 github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/assisted-service v1.0.10-0.20201117161456-e97b039ef0c0 h1:7dM/PYUVMa23nXjJ5Fv8aVKZJSxY6tH6hyF5AB9HwQU=
 github.com/openshift/assisted-service v1.0.10-0.20201117161456-e97b039ef0c0/go.mod h1:1fJjNU9dl8rXqfIqxRKcrB8D+f43QhzMDVnyf9I5/uI=
+github.com/openshift/assisted-service v1.0.10-0.20201123173047-fc89b94631c2 h1:LbPcvkbYuv8ak95LId05/owoIwCAuj18TbJ6kNu7zG4=
+github.com/openshift/assisted-service v1.0.10-0.20201123173047-fc89b94631c2/go.mod h1:1fJjNU9dl8rXqfIqxRKcrB8D+f43QhzMDVnyf9I5/uI=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c h1:RAgi0xFIHMpsGmYEXoPyZn3Gjomkj/9aCERcqxJP7mc=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20200820213150-b2b74d7c6a5c/go.mod h1:+duukQisb5LU1bMtLalsHZc1wM69D5sH3TuiyvAQhhA=

--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -69,6 +69,22 @@ func (d *disks) getBootable(path string) bool {
 	return strings.Contains(stdout, "DOS/MBR boot sector")
 }
 
+func (d *disks) getSMART(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	stdout, stderr, exitCode := d.dependencies.Execute("smartctl", "--xall", "--json=c", path)
+
+	if exitCode != 0 {
+		logrus.Warnf("Could not get S.M.A.R.T. information for path %s: (smartctl exit code %d) %s",
+			path, exitCode, stderr)
+		return ""
+	}
+
+	return stdout
+}
+
 func unknownToEmpty(value string) string {
 	if value == ghw.UNKNOWN {
 		return ""
@@ -113,6 +129,7 @@ func (d *disks) getDisks() []*models.Disk {
 			Vendor:    unknownToEmpty(disk.Vendor),
 			Wwn:       unknownToEmpty(disk.WWN),
 			Bootable:  d.getBootable(path),
+			Smart:     d.getSMART(path),
 		}
 		ret = append(ret, &rec)
 	}


### PR DESCRIPTION
- Updated assisted service to latest version
- Using smartctl to populate the Smart field in inventory host disks
- Organized disks_test.go a bit