### PR TITLE
MGMT-2777 Adapt IPv6 network prefix by using RA routes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/thoas/go-funk v0.7.0
 	github.com/vishvananda/netlink v1.1.0
+	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 	gopkg.in/yaml.v2 v2.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -639,6 +639,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
+github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/src/inventory/dependencies.go
+++ b/src/inventory/dependencies.go
@@ -24,6 +24,7 @@ type IDependencies interface {
 	Abs(path string) (string, error)
 	EvalSymlinks(path string) (string, error)
 	LinkByName(name string) (netlink.Link, error)
+	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
 }
 
 type Dependencies struct{}
@@ -78,6 +79,10 @@ func (d *Dependencies) EvalSymlinks(path string) (string, error) {
 
 func (*Dependencies) LinkByName(name string) (netlink.Link, error) {
 	return netlink.LinkByName(name)
+}
+
+func (*Dependencies) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
+	return netlink.RouteList(link, family)
 }
 
 func newDependencies() IDependencies {

--- a/src/inventory/interfaces.go
+++ b/src/inventory/interfaces.go
@@ -177,6 +177,7 @@ func (i *interfaces) getInterfaces() []*models.Interface {
 		}
 		ret = append(ret, &rec)
 	}
+	setV6PrefixesForAddresses(ret, i.dependencies)
 	return ret
 }
 

--- a/src/inventory/mock_IDependencies.go
+++ b/src/inventory/mock_IDependencies.go
@@ -264,6 +264,29 @@ func (_m *MockIDependencies) ReadFile(fname string) ([]byte, error) {
 	return r0, r1
 }
 
+// RouteList provides a mock function with given fields: link, family
+func (_m *MockIDependencies) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
+	ret := _m.Called(link, family)
+
+	var r0 []netlink.Route
+	if rf, ok := ret.Get(0).(func(netlink.Link, int) []netlink.Route); ok {
+		r0 = rf(link, family)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]netlink.Route)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(netlink.Link, int) error); ok {
+		r1 = rf(link, family)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Stat provides a mock function with given fields: fname
 func (_m *MockIDependencies) Stat(fname string) (os.FileInfo, error) {
 	ret := _m.Called(fname)

--- a/src/inventory/routes.go
+++ b/src/inventory/routes.go
@@ -1,0 +1,88 @@
+package inventory
+
+import (
+	"net"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/assisted-service/models"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+type routeFinder struct {
+	dependencies IDependencies
+}
+
+func newRouteFinder(dependencies IDependencies) *routeFinder {
+	return &routeFinder{dependencies:dependencies}
+}
+
+
+// usableIPv6Route returns true if the passed route is acceptable for AddressesRouting
+func usableIPv6Route(route netlink.Route) bool {
+	// Ignore default routes
+	if route.Dst == nil {
+		return false
+	}
+	// Ignore non-IPv6 routes
+	if net.IPv6len != len(route.Dst.IP) {
+		return false
+	}
+	// Ignore non-advertised routes
+	if route.Protocol != unix.RTPROT_RA {
+		return false
+	}
+
+	return true
+}
+
+func (r *routeFinder) getLinkV6Routes(linkName string) (routeList []netlink.Route, err error) {
+	link, err := r.dependencies.LinkByName(linkName)
+	if err != nil {
+		return nil, err
+	}
+	routes, err := r.dependencies.RouteList(link, netlink.FAMILY_V6)
+	if err != nil {
+		return nil, err
+	}
+
+	routeList = make([]netlink.Route, 0)
+	for _, route := range routes {
+		if !usableIPv6Route(route) {
+			logrus.Debugf("Ignoring filtered route %+v", route)
+			continue
+		}
+		routeList = append(routeList, route)
+	}
+
+	return routeList, nil
+}
+
+func setV6PrefixesForAddresses(interfaces []*models.Interface, dependencies IDependencies) {
+	finder := newRouteFinder(dependencies)
+	for _, intf := range interfaces {
+		if len(intf.IPV6Addresses) == 0 {
+			continue
+		}
+		routes, err := finder.getLinkV6Routes(intf.Name)
+		if err != nil {
+			logrus.WithError(err).Warnf("Could not get routes for interface %s", intf.Name)
+			continue
+		}
+		for i, addr := range intf.IPV6Addresses {
+			ip, _, err := net.ParseCIDR(addr)
+			if err != nil {
+				logrus.WithError(err).Warnf("Could not parse CIDR %s", addr)
+				continue
+			}
+			for _, route := range routes {
+				containmentNet := net.IPNet{IP: route.Dst.IP, Mask: route.Dst.Mask}
+				if containmentNet.Contains(ip) {
+					intf.IPV6Addresses[i] = (&net.IPNet{IP: ip, Mask: route.Dst.Mask}).String()
+					break
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
    IPV6 addresses many times don't have the correct network prefix associated.  Instead,
    a prefix values of 128 is attached.  Since we need this prefix to calculate host-networks
    and Machine Network CIDR, this value needs to be fixed.
    The change takes the correct network prefix from Route Advertisement records
    and fixes them in the IPv6 addresses that are returned as part of the inventory.
