### PR TITLE
NO-ISSUE: Changing the order of logs gathering.

### DIFF
--- a/src/logs_sender/send_logs_test.go
+++ b/src/logs_sender/send_logs_test.go
@@ -83,8 +83,17 @@ var _ = Describe("logs sender", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("GatherInstallerLogs failed", func() {
+		folderSuccess()
+		logsSenderMock.On("GatherInstallerLogs", logsTmpFilesDir).Return(errors.New("Dummy"))
+		err := SendLogs(logsSenderMock)
+		fmt.Println(err)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("ExecuteOutputToFile failed", func() {
 		folderSuccess()
+		gatherInstallerLogsSuccess()
 		outputPath := path.Join(logsTmpFilesDir, fmt.Sprintf("%s.logs", config.LogsSenderConfig.Tags[0]))
 		logsSenderMock.On("ExecuteOutputToFile", outputPath, "journalctl", "-D", "/var/log/journal/",
 			"--since", config.LogsSenderConfig.Since, "--all", fmt.Sprintf("TAG=%s", config.LogsSenderConfig.Tags[0])).
@@ -94,19 +103,10 @@ var _ = Describe("logs sender", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("GatherInstallerLogs failed", func() {
-		folderSuccess()
-		executeOutputToFileSuccess()
-		logsSenderMock.On("GatherInstallerLogs", logsTmpFilesDir).Return(errors.New("Dummy"))
-		err := SendLogs(logsSenderMock)
-		fmt.Println(err)
-		Expect(err).To(HaveOccurred())
-	})
-
 	It("Archive failed", func() {
 		folderSuccess()
-		executeOutputToFileSuccess()
 		gatherInstallerLogsSuccess()
+		executeOutputToFileSuccess()
 		logsSenderMock.On("Execute", "tar", "-czvf", archivePath, "-C", filepath.Dir(logsTmpFilesDir),
 			filepath.Base(logsTmpFilesDir)).
 			Return("Dummy", "Dummy", -1)
@@ -117,8 +117,8 @@ var _ = Describe("logs sender", func() {
 
 	It("Upload failed", func() {
 		folderSuccess()
-		executeOutputToFileSuccess()
 		gatherInstallerLogsSuccess()
+		executeOutputToFileSuccess()
 		archiveSuccess()
 		logsSenderMock.On("FileUploader", archivePath, strfmt.UUID(config.LogsSenderConfig.ClusterID),
 			strfmt.UUID(config.LogsSenderConfig.HostID), config.LogsSenderConfig.TargetURL, config.LogsSenderConfig.PullSecretToken, config.GlobalAgentConfig.AgentVersion).
@@ -130,8 +130,8 @@ var _ = Describe("logs sender", func() {
 
 	It("Happy flow", func() {
 		folderSuccess()
-		executeOutputToFileSuccess()
 		gatherInstallerLogsSuccess()
+		executeOutputToFileSuccess()
 		archiveSuccess()
 		logsSenderMock.On("FileUploader", archivePath, strfmt.UUID(config.LogsSenderConfig.ClusterID),
 			strfmt.UUID(config.LogsSenderConfig.HostID), config.LogsSenderConfig.TargetURL, config.LogsSenderConfig.PullSecretToken, config.GlobalAgentConfig.AgentVersion).


### PR DESCRIPTION
Moved installer-gather to run first so its own logs are included in the
gathered agent logs.

Before the change:
```
...
Nov 25 06:12:37 test-infra-cluster-assisted-installer-master-0 logs_sender[11609]: time="25-11-2020 06:12:37" level=info msg="Start gathering journalctl logs with tags [agent installer] and services [bootkube]" file="send_logs.go:146"
Nov 25 06:12:37 test-infra-cluster-assisted-installer-master-0 logs_sender[11609]: time="25-11-2020 06:12:37" level=info msg="Running journalctl with filters [TAG=agent]" file="send_logs.go:109"
```

After the change:
```
...
Nov 25 07:03:58 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:03:58" level=info msg="Start gathering journalctl logs with tags [agent installer], services [bootkube] and installer-gather" file="send_logs.go:146"
Nov 25 07:03:58 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:03:58" level=info msg="Running /usr/local/bin/installer-gather.sh [--id 20201125070358 192.168.126.11 192.168.126.10]" file="send_logs.go:90"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering bootstrap systemd summary ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering bootstrap failed systemd unit status ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering bootstrap journals ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering bootstrap containers ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering rendered assets..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering cluster resources ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Waiting for logs ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gather remote logs" file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Collecting info from 192.168.126.11" file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering master systemd summary ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering master failed systemd unit status ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering master journals ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering master containers ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Waiting for logs ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Collecting info from 192.168.126.10" file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering master systemd summary ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering master failed systemd unit status ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering master journals ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Gathering master containers ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Waiting for logs ..." file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: Log bundle written to /root/log-bundle-20201125070358.tar.gz" file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="installer-gather log: " file="send_logs.go:94"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=warning msg="Failed to run /usr/local/bin/installer-gather.sh [--id 20201125070358 192.168.126.11 192.168.126.10]" file="send_logs.go:97" error="rm: cannot remove '/tmp/artifacts-20201125070358/rendered-assets/openshift/etcd-bootstrap/bootstrap-manifests/secrets': Is a directory\nerror: error executing jsonpath \"{range .items[*]}{.metadata.name}{\\\"\\\\n\\\"}{end}\": Error executing template: not in range, nothing to end. Printing more information for debugging the template:\n\ttemplate was:\n\t\t{range .items[*]}{.metadata.name}{\"\\n\"}{end}\n\tobject given to jsonpath engine was:\n\t\tmap[string]interface {}{\"apiVersion\":\"v1\", \"items\":[]interface {}{}, \"kind\":\"List\", \"metadata\":map[string]interface {}{\"resourceVersion\":\"\", \"selfLink\":\"\"}}\n\n\nerror: error executing jsonpath \"{range .items[*]}{.metadata.name}{\\\"\\\\n\\\"}{end}\": Error executing template: not in range, nothing to end. Printing more information for debugging the template:\n\ttemplate was:\n\t\t{range .items[*]}{.metadata.name}{\"\\n\"}{end}\n\tobject given to jsonpath engine was:\n\t\tmap[string]interface {}{\"apiVersion\":\"v1\", \"items\":[]interface {}{}, \"kind\":\"List\", \"metadata\":map[string]interface {}{\"resourceVersion\":\"\", \"selfLink\":\"\"}}\n\n\nWarning: Permanently added '192.168.126.11' (ECDSA) to the list of known hosts.\r\nWarning: Permanently added '192.168.126.10' (ECDSA) to the list of known hosts.\r\n"
Nov 25 07:04:10 test-infra-cluster-assisted-installer-master-2 logs_sender[11660]: time="25-11-2020 07:04:10" level=info msg="Running journalctl with filters [TAG=agent]" file="send_logs.go:109"
```

Signed-off-by: Yoni Bettan <ybettan@redhat.com>