### PR TITLE
MGMT-3120 IPv6 connectivity check

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -15,7 +15,10 @@ RUN dnf install -y \
 		# logs_sender
 		tar \
 		# ntp_synchronizer
-		chrony && \
+		chrony \
+		# connectivity_check
+		# ndisc6 for IPv6 is not included in the repo https://bugzilla.redhat.com/show_bug.cgi?id=1779134
+		https://cbs.centos.org/kojifiles/packages/ndisc6/1.0.3/9.el8/x86_64/ndisc6-1.0.3-9.el8.x86_64.rpm && \
 		dnf update -y systemd && dnf clean all
 ADD build/agent build/connectivity_check build/free_addresses build/inventory \
 	build/logs_sender build/dhcp_lease_allocate build/apivip_check build/next_step_runner build/ntp_synchronizer \

--- a/src/connectivity_check/main/main.go
+++ b/src/connectivity_check/main/main.go
@@ -15,7 +15,7 @@ func main() {
 	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	util.SetLogging("connectivity-check", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging)
 	if flag.NArg() != 1 {
-		log.Warnf("Expecting exactly single argument to connectivity check. Recieved %d", len(os.Args)-1)
+		log.Warnf("Expecting exactly single argument to connectivity check. Received %d", len(os.Args)-1)
 		os.Exit(-1)
 	}
 	stdout, stderr, exitCode := commands.ConnectivityCheck("", flag.Arg(0))

--- a/src/util/network.go
+++ b/src/util/network.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"net"
+	"strings"
+)
+
+// IsIPv4Addr returns true if the input is a valid IPv4 address
+func IsIPv4Addr(ip string) bool {
+	return strings.Contains(ip, ".") && net.ParseIP(ip) != nil
+}


### PR DESCRIPTION
Use ndisc6 to check L2 connectivity between nodes and receive a remote's MAC address.
For now there is a limitation that the outgoing IP address cannot be detected.