### PR TITLE
MGMT-3211 - Never ignore smartctl, regardless of exit code

### DIFF
--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -74,13 +74,10 @@ func (d *disks) getSMART(path string) string {
 		return ""
 	}
 
-	stdout, stderr, exitCode := d.dependencies.Execute("smartctl", "--xall", "--json=c", path)
-
-	if exitCode != 0 {
-		logrus.Warnf("Could not get S.M.A.R.T. information for path %s: (smartctl exit code %d) %s",
-			path, exitCode, stderr)
-		return ""
-	}
+	// We ignore the exit code and stderr because stderr is empty and
+	// stdout contains the exit code in `--json=c` mode. Whatever the exit
+	// code is, we want to relay the information to the service
+	stdout, _, _ := d.dependencies.Execute("smartctl", "--xall", "--json=c", path)
 
 	return stdout
 }

--- a/src/inventory/disks_test.go
+++ b/src/inventory/disks_test.go
@@ -99,12 +99,13 @@ var _ = Describe("Disks test", func() {
 		It("Without a smartctl error", func() {
 			dependencies.On("Execute", "file", "-s", "/dev/foo/disk1").Return(" DOS/MBR boot sector", "", 0).Once()
 			dependencies.On("Execute", "smartctl", "--xall", "--json=c", "/dev/foo/disk1").Return(`{"some": "json"}`, "", 0).Once()
+			expectation[0].Smart = `{"some": "json"}`
 		})
 
-		It("With a smartctl error", func() {
+		It("With a smartctl error - make sure JSON is still transmitted", func() {
 			dependencies.On("Execute", "file", "-s", "/dev/foo/disk1").Return(" DOS/MBR boot sector", "", 0).Once()
-			dependencies.On("Execute", "smartctl", "--xall", "--json=c", "/dev/foo/disk1").Return(`{"some": "error"}`, "", 2).Once()
-			expectation[0].Smart = ""
+			dependencies.On("Execute", "smartctl", "--xall", "--json=c", "/dev/foo/disk1").Return(`{"some": "json"}`, "", 1).Once()
+			expectation[0].Smart = `{"some": "json"}`
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
Turns out [smartctl exit-codes are meaningful](https://linux.die.net/man/8/smartctl) (See "Return Values" section).

In the current implementation of the agent's smartctl invocation, it's assumed that non-zero exit code is smartctl itself failing, but turns out smartctl also communicates *disk* failures via its exit code as linked above.

What we did prior to this PR is simply discard all S.M.A.R.T. information when the exit-code is non-zero, which is the worst thing we could possibly do - because when the exit code indicates disk failure, that's when the SMART info is most interesting to relay to the service.

Proposed change:
EDIT: Simply ignore the exit code. Pass the output to the service. Let it decide on its own what to do with that information.

For the record, this is the parsing that was suggested before the above edit:
> Parse the exit code, treat each bit as follows:
> 
> Bit 0 1
> Meaning: No smart data / bad invocation / no permissions -
> What we need to do: Print a warning. Nothing we can do, ignore SMART for this device
> 
> Bit 2 -
> Meaning: Corrupt SMART data. We can't trust parsing it will make any sense. And yet, I've seen this happen on a device where there was still SMART data and nothing seemingly wrong with it. There was an error coming from one ioctl call that might have caused it to turn on bit 2 in the exit code, but it seemed interesting, not something we would like to discard.
> What we need to do: Keep the smart data. Might remove it in the future if it causes problems during parsing. See bits 3 4 5 6 7
> 
> Bit 3 4 5 6 7 -
> Meaning: Something is off with the disk.
> What we need to do: The service can parse this field: *sudo smartctl --xall /dev/sda --json=c | jq '.smartctl.exit_status'* to get the exit code, no need to add anything to the API