### PR TITLE
MGMT-3194 Use nmap for L2 connectivity check

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -15,10 +15,7 @@ RUN dnf install -y \
 		# logs_sender
 		tar \
 		# ntp_synchronizer
-		chrony \
-		# connectivity_check
-		# ndisc6 for IPv6 is not included in the repo https://bugzilla.redhat.com/show_bug.cgi?id=1779134
-		https://cbs.centos.org/kojifiles/packages/ndisc6/1.0.3/9.el8/x86_64/ndisc6-1.0.3-9.el8.x86_64.rpm && \
+		chrony && \
 		dnf update -y systemd && dnf clean all
 ADD build/agent build/connectivity_check build/free_addresses build/inventory build/fio_perf_check \
 	build/logs_sender build/dhcp_lease_allocate build/apivip_check build/next_step_runner build/ntp_synchronizer \

--- a/src/commands/connectivity_check_test.go
+++ b/src/commands/connectivity_check_test.go
@@ -1,0 +1,343 @@
+package commands
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+)
+
+const nmapOut = `
+<nmaprun>
+	<host>
+		<status state="up" />
+		<address addr="2001:db8::2" addrtype="ipv6" />
+		<address addr="02:42:AC:12:00:02" addrtype="mac" />
+	</host>
+</nmaprun>`
+
+var _ = ginkgo.Describe("nmap analysis test", func() {
+
+	ginkgo.It("Happy flow", func(done ginkgo.Done) {
+
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(nmapOut), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "02:42:ac:12:00:02",
+			Successful:        true,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("Command error", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(nmapOut), fmt.Errorf("nmap command failed")
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "",
+			Successful:        false,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("Invalid XML", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte("plain text"), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "",
+			Successful:        false,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("Host down", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(`
+			<nmaprun>
+				<host>
+					<status state="down" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+					<address addr="02:42:AC:12:00:02" addrtype="mac" />
+				</host>
+			</nmaprun>`), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "",
+			Successful:        false,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("Lower-case destination MAC address", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(nmapOut), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "02:42:ac:12:00:02",
+			Successful:        true,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:ac:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("Lower-case discovered MAC address", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(`
+			<nmaprun>
+				<host>
+					<status state="up" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+					<address addr="02:42:ac:12:00:02" addrtype="mac" />
+				</host>
+			</nmaprun>`), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "02:42:ac:12:00:02",
+			Successful:        true,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("No MAC address", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(`
+			<nmaprun>
+				<host>
+					<status state="up" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+				</host>
+			</nmaprun>`), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "",
+			Successful:        false,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("No hosts", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte("<nmaprun />"), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "",
+			Successful:        false,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("First matching host", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(`
+			<nmaprun>
+				<host>
+					<status state="up" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+					<address addr="02:42:AC:AA:00:02" addrtype="mac" />
+				</host>
+				<host>
+					<status state="up" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+					<address addr="02:42:AC:12:00:02" addrtype="mac" />
+				</host>
+			</nmaprun>`), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "02:42:ac:aa:00:02",
+			Successful:        false,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("Multiple hosts, only one up", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(`
+			<nmaprun>
+				<host>
+					<status state="down" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+					<address addr="02:42:AC:AA:00:02" addrtype="mac" />
+				</host>
+				<host>
+					<status state="up" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+					<address addr="02:42:AC:12:00:02" addrtype="mac" />
+				</host>
+			</nmaprun>`), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "02:42:ac:12:00:02",
+			Successful:        true,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("Multiple hosts, only one has a MAC address", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(`
+			<nmaprun>
+				<host>
+					<status state="up" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+				</host>
+				<host>
+					<status state="up" />
+					<address addr="2001:db8::2" addrtype="ipv6" />
+					<address addr="02:42:AC:12:00:02" addrtype="mac" />
+				</host>
+			</nmaprun>`), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "02:42:ac:12:00:02",
+			Successful:        true,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:AC:12:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("Unexpected MAC address", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(nmapOut), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "02:42:ac:12:00:02",
+			Successful:        false,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:CC:14:00:02", []string{"02:42:B:14:00:02", "02:42:C:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+
+	ginkgo.It("MAC different than tried", func(done ginkgo.Done) {
+		out := make(chan Any, 100)
+
+		xml := func() ([]byte, error) {
+			return []byte(nmapOut), nil
+		}
+
+		expected := &models.L2Connectivity{
+			OutgoingNic:       "eth0",
+			OutgoingIPAddress: "",
+			RemoteIPAddress:   "2001:db8::2",
+			RemoteMac:         "02:42:ac:12:00:02",
+			Successful:        true,
+		}
+
+		analyzeNmap("2001:db8::2", "02:42:CC:10:00:02", []string{"02:42:AC:12:00:02", "02:42:AC:14:00:02"}, "eth0", out, xml)
+		Expect(<-out).To(Equal(expected))
+		close(done)
+	}, 0.2)
+})
+
+func TestConnectivityCheck(t *testing.T) {
+	RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "connectivity check tests")
+}

--- a/src/free_addresses/free_addresses.go
+++ b/src/free_addresses/free_addresses.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-installer-agent/src/util"
+	"github.com/openshift/assisted-installer-agent/src/util/nmap"
 	"github.com/pkg/errors"
 
 	"github.com/openshift/assisted-service/models"
@@ -28,26 +29,6 @@ type ProcessExecuter struct{}
 
 func (e *ProcessExecuter) Execute(command string, args ...string) (stdout string, stderr string, exitCode int) {
 	return util.Execute(command, args...)
-}
-
-type status struct {
-	State  string `xml:"state,attr"`
-	Reason string `xml:"reason,attr"`
-}
-
-type address struct {
-	Addr     string `xml:"addr,attr"`
-	AddrType string `xml:"addrtype,attr"`
-}
-
-type host struct {
-	Status    status     `xml:"status"`
-	Addresses []*address `xml:"address"`
-}
-
-type nmaprun struct {
-	XMLName xml.Name `xml:"nmaprun"`
-	Hosts   []*host  `xml:"host"`
 }
 
 //  http://play.golang.org/p/m8TNTtygK0
@@ -113,7 +94,7 @@ func (s *scanner) scanSubNetwork(subNetwork string) ([]strfmt.IPv4, string, int)
 		s.log.Warnf("nmap failed with exit-code %d: %s", exitCode, e)
 		return nil, e, exitCode
 	}
-	var nmaprun nmaprun
+	var nmaprun nmap.Nmaprun
 	err = xml.Unmarshal([]byte(o), &nmaprun)
 	if err != nil {
 		s.log.WithError(err).Warn("XML Unmarshal")

--- a/src/util/nmap/types.go
+++ b/src/util/nmap/types.go
@@ -1,0 +1,23 @@
+package nmap
+
+import "encoding/xml"
+
+type Status struct {
+	State  string `xml:"state,attr"`
+	Reason string `xml:"reason,attr"`
+}
+
+type Address struct {
+	Addr     string `xml:"addr,attr"`
+	AddrType string `xml:"addrtype,attr"`
+}
+
+type Host struct {
+	Status    Status     `xml:"status"`
+	Addresses []*Address `xml:"address"`
+}
+
+type Nmaprun struct {
+	XMLName xml.Name `xml:"nmaprun"`
+	Hosts   []*Host  `xml:"host"`
+}


### PR DESCRIPTION
Replace ndisc6 because it cannot handle concurrent discovery