### PR TITLE
Get test images from quay.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ unit-test: $(REPORTS)
 
 subsystem: build-image
 	$(DOCKER_COMPOSE) up --build -d
+	-rm -rf $(ROOT_DIR)/subsystem/data/dhcpd.leases*
+	touch $(ROOT_DIR)/subsystem/data/dhcpd.leases
 	$(MAKE) _test TEST_SCENARIO=subsystem TEST="./subsystem/..." SKIP="system-test" || ($(DOCKER_COMPOSE) down && /bin/false)
 	$(DOCKER_COMPOSE) down
 

--- a/subsystem/docker-compose.yml
+++ b/subsystem/docker-compose.yml
@@ -30,20 +30,20 @@ services:
       ]
 
   dhcpd:
-    image: networkboot/dhcpd
+    image: quay.io/cloudctl/dhcp:ubi
     container_name: dhcpd
     cap_add:
-      - net_raw
+      - NET_ADMIN
     volumes:
-      - ${ROOT_DIR}/subsystem/data:/data
+      - ${ROOT_DIR}/subsystem/data:/etc/dhcp:z
+      - ${ROOT_DIR}/subsystem/data:/tmp/leases:z
     networks:
       agent_network:
     environment:
       - ROOT_DIR
-    command: eth0
 
   wiremock:
-    image: "rodolpheche/wiremock"
+    image: quay.io/ocpmetal/wiremock
     ports:
       - "${WIREMOCK_PORT}:${WIREMOCK_PORT}"
     networks:


### PR DESCRIPTION
Use quay.io images for subsystem images - dhcpd, wiremock