### PR TITLE
Move cloudctl/dhcp:ubi to cloudctl/dhcp:latest

### DIFF
--- a/subsystem/docker-compose.yml
+++ b/subsystem/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       ]
 
   dhcpd:
-    image: quay.io/cloudctl/dhcp:ubi
+    image: quay.io/cloudctl/dhcp:latest
     container_name: dhcpd
     cap_add:
       - NET_ADMIN


### PR DESCRIPTION
quay.io/cloudctl/dhcp:ubi tag was deleted. For now moving to latest tag