### PR TITLE
MGMT-3315 Multi-stage agent Dockerfile

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -1,3 +1,16 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
+ENV GO111MODULE=on
+ENV GOFLAGS=""
+
+WORKDIR /go/src/github.com/openshift/assisted-installer-agent
+
+COPY go.mod .
+RUN go mod download
+
+COPY . .
+
+RUN make build
+
 FROM quay.io/centos/centos:centos8
 RUN dnf install -y \
 		findutils iputils \
@@ -17,7 +30,14 @@ RUN dnf install -y \
 		# ntp_synchronizer
 		chrony && \
 		dnf update -y systemd && dnf clean all
-ADD build/agent build/connectivity_check build/free_addresses build/inventory build/fio_perf_check \
-	build/logs_sender build/dhcp_lease_allocate build/apivip_check build/next_step_runner build/ntp_synchronizer \
-	/usr/bin/
 
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/agent /usr/bin/agent
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/connectivity_check /usr/bin/connectivity_check
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/free_addresses /usr/bin/free_addresses
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/inventory /usr/bin/inventory
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/fio_perf_check /usr/bin/fio_perf_check
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/logs_sender /usr/bin/logs_sender
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/dhcp_lease_allocate /usr/bin/dhcp_lease_allocate
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/apivip_check /usr/bin/apivip_check
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/next_step_runner /usr/bin/next_step_runner
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/ntp_synchronizer /usr/bin/ntp_synchronizer

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build: build-agent build-connectivity_check build-inventory build-free_addresses
 build-%: $(BIN) src/$*
 	CGO_ENABLED=0 go build -o $(BIN)/$* src/$*/main/main.go
 
-build-image: unit-test build
+build-image: unit-test
 	docker build --network=host -f Dockerfile.assisted_installer_agent . -t $(ASSISTED_INSTALLER_AGENT)
 
 push: build-image subsystem


### PR DESCRIPTION
Updated Dockerfile to build without running `make build` first.

I tested the `skipper make build-image` and `skipper make subsystem` locally as well.