### PR TITLE
MGMT-4346 collect logs from containers in Jenkins Post

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,8 @@ pipeline {
                       }
                       sh '''curl -X POST -H 'Content-type: application/json' --data-binary "@data.txt" https://hooks.slack.com/services/${SLACK_TOKEN}'''
                 }
+                sh 'sudo journalctl TAG=agent --since="1 hour ago" > agent_journalctl.log  || true'
+                archiveArtifacts artifacts: '*.log', fingerprint: true
             }
         }
   }

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ unit-test: $(REPORTS)
 
 subsystem: build-image
 	$(DOCKER_COMPOSE) up --build -d dhcpd wiremock
-	$(MAKE) _test TEST_SCENARIO=subsystem TEST="./subsystem/..." SKIP="system-test" || ($(DOCKER_COMPOSE) down && /bin/false)
+	-$(MAKE) _test TEST_SCENARIO=subsystem TEST="./subsystem/..." SKIP="system-test"
+	$(DOCKER_COMPOSE) logs dhcpd > dhcpd.log
+	$(DOCKER_COMPOSE) logs wiremock > wiremock.log
 	$(DOCKER_COMPOSE) down
 
 generate:


### PR DESCRIPTION
* Currently collects from the following containers:
  - dhcp
  - wiremock
* Collect agent journal (last hour).

The subsystem call to `_test` Makefile entery was added with a '`-`' prefix to ignore errors, as stated https://www2.ipp.mpg.de/~dpc/gmake/make_47.html

The reason that it would otherwise stop execution with a failed test and won't collect the logs, which we obviously want, especially in those cases.