### PR TITLE
NO-ISSUE: Use 'Errorf' instead of 'Infof' for step failure

### DIFF
--- a/src/commands/step_processor.go
+++ b/src/commands/step_processor.go
@@ -78,7 +78,7 @@ func (s *stepSession) handleSingleStep(stepType models.StepType, stepID string, 
 	s.Logger().Infof("Executing step: <%s>, command: <%s>, args: <%v>", stepID, command, args)
 	stdout, stderr, exitCode := handler(command, args...)
 	if exitCode != 0 {
-		s.Logger().Infof(`Step execution failed (exit code %v): <%s>, command: <%s>, args: <%v>. Output:
+		s.Logger().Errorf(`Step execution failed (exit code %v): <%s>, command: <%s>, args: <%v>. Output:
 stdout:
 %v
 


### PR DESCRIPTION
Logging the step execution failure with Error instead of Info message will help in analyzing logs quickly for failures.