### PR TITLE
OCPBUGSM-27560 Duplicate installation disk. (#192)

### DIFF
--- a/src/inventory/disks_test.go
+++ b/src/inventory/disks_test.go
@@ -806,5 +806,24 @@ var _ = Describe("Disks test", func() {
 			Ω(disk.ByID).Should(BeEmpty())
 			Ω(disk.ID).Should(Equal(disk.ByPath))
 		})
+
+		It("Duplicate busType", func() {
+			mockGetWWNCallForSuccess(dependencies, make(map[string]string))
+			sda := createSDADisk()
+			sdd := createSDADisk()
+			sdd.Name = "sdd"
+			mockAllForSuccess(dependencies, sda, sdd)
+			path := fmt.Sprintf("/dev/disk/by-path/%s", sda.BusPath)
+			util.DeleteExpectedMethod(&dependencies.Mock, "Stat", path)
+			util.DeleteExpectedMethod(&dependencies.Mock, "Stat", path)
+			ret := GetDisks(dependencies)
+			Ω(ret).Should(HaveLen(2))
+			disk := ret[0]
+			Ω(disk.ByID).Should(BeEmpty())
+			Ω(disk.ID).Should(Equal(disk.Path))
+			disk = ret[1]
+			Ω(disk.ByID).Should(BeEmpty())
+			Ω(disk.ID).Should(Equal(disk.Path))
+		})
 	})
 })


### PR DESCRIPTION
Support special case where two disk shares the same busType. We prefer to pretend they have no bus path at all, to avoid confusing between them

(cherry picked from commit e217062c630886a821eefecaa3fc3ab62cc1a0b6)