### PR TITLE
OCPBUGSM-27088 Filter out ipv6 local link addresses from inventory.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/jaypipes/ghw v0.7.0
 	github.com/jaypipes/pcidb v0.6.0
-	github.com/metal3-io/baremetal-operator v0.0.0 // indirect
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
 	github.com/openshift/assisted-service v1.0.10-0.20210412070223-659b5dab9f67
@@ -25,7 +24,6 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 	gopkg.in/yaml.v2 v2.4.0
-	honnef.co/go/tools v0.0.1-2020.1.6 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -940,16 +940,12 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2/go.m
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.5.1/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
-github.com/openshift-online/ocm-sdk-go v0.1.160 h1:IrmZoTmPiqa8VmdthDcztWHmXHeHiFDvF5wife6hYdc=
-github.com/openshift-online/ocm-sdk-go v0.1.160/go.mod h1:9y8jM+VhZdl5VLy8l3RI+uDltcWPL1oW6lqtjtoDHqY=
 github.com/openshift-online/ocm-sdk-go v0.1.165 h1:NndMhSbJzTsBgZuoIgDhHHmk6pgF9rYmJOYikAunJxg=
 github.com/openshift-online/ocm-sdk-go v0.1.165/go.mod h1:/DStCZJQ2XOV/ktkODyVnUCPnGfH3agwp0e+GZTLr3E=
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267/go.mod h1:RDvBcRQMGLa3aNuDuejVBbTEQj/2i14NXdpOLqbNBvM=
 github.com/openshift/api v0.0.0-20210216211028-bb81baaf35cd/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
-github.com/openshift/assisted-service v1.0.10-0.20210330171458-790c68adcee8 h1:AfMYHz0ZyjiTBXWna4p5GVQW4ac0qWQ3q97D9+bvNE0=
-github.com/openshift/assisted-service v1.0.10-0.20210330171458-790c68adcee8/go.mod h1:9Raz9UF9t/ocLHuhXREehRFsipHOM6CG43oxVgVJBII=
 github.com/openshift/assisted-service v1.0.10-0.20210412070223-659b5dab9f67 h1:WBxHFMjtxLp0cBPEmXiWIBkfYPkssTLIf+UYXc9YIRk=
 github.com/openshift/assisted-service v1.0.10-0.20210412070223-659b5dab9f67/go.mod h1:Hz+8t0WEpZzC44OjjopgCtFONrXjotYZVa3kjDfc+ig=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
@@ -1596,7 +1592,6 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
-golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200430192856-2840dafb9ee1/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -1775,7 +1770,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb h1:jhnBjNi9UFpfpl8YZhA9CrOqpnJdvzuiHsl/dnxl11M=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.0.0-20190712022805-31fe033ae6f9 h1:sbrvmfIQxEkFARFDPWY7DMwG+1cGcFwOzfACZbfFhY4=

--- a/src/inventory/interfaces_test.go
+++ b/src/inventory/interfaces_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Interfaces", func() {
 	})
 
 	It("Single result", func() {
-		interfaceMock := newFilledInterfaceMock(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "fe80::d832:8def:dd51:3527/128"}, true, false, false, 1000)
+		interfaceMock := newFilledInterfaceMock(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, true, false, false, 1000)
 		dependencies.On("Interfaces").Return([]util.Interface{interfaceMock}, nil).Once()
 		dependencies.On("Execute", "biosdevname", "-i", "eth0").Return("em2", "", 0).Once()
 		dependencies.On("ReadFile", "/sys/class/net/eth0/carrier").Return([]byte("1\n"), nil).Once()
@@ -90,7 +90,7 @@ var _ = Describe("Interfaces", func() {
 		dependencies.On("LinkByName", "eth0").Return(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}, nil).Once()
 		dependencies.On("RouteList", mock.Anything, mock.Anything).Return([]netlink.Route{
 			{
-				Dst:      &net.IPNet{IP: net.ParseIP("fe80::"), Mask: net.CIDRMask(64, 128)},
+				Dst:      &net.IPNet{IP: net.ParseIP("de90::"), Mask: net.CIDRMask(64, 128)},
 				Protocol: unix.RTPROT_RA,
 			},
 		}, nil)
@@ -102,7 +102,7 @@ var _ = Describe("Interfaces", func() {
 				Flags:         []string{"up", "broadcast"},
 				HasCarrier:    true,
 				IPV4Addresses: []string{"10.0.0.18/24"},
-				IPV6Addresses: []string{"fe80::d832:8def:dd51:3527/64"},
+				IPV6Addresses: []string{"de90::d832:8def:dd51:3527/64"},
 				MacAddress:    "f8:75:a4:a4:00:fe",
 				Mtu:           1500,
 				Name:          "eth0",
@@ -114,11 +114,11 @@ var _ = Describe("Interfaces", func() {
 	})
 	It("Multiple results", func() {
 		rets := []util.Interface{
-			newFilledInterfaceMock(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "192.168.6.7/20", "fe80::d832:8def:dd51:3527/128"}, true, false, false, 100),
-			newFilledInterfaceMock(1400, "eth1", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.19/24", "192.168.6.8/20", "fe80::d832:8def:dd51:3528/127"}, true, false, false, 10),
-			newFilledInterfaceMock(1400, "eth2", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.20/24", "192.168.6.9/20", "fe80::d832:8def:dd51:3529/126"}, false, false, false, 5),
-			newFilledInterfaceMock(1400, "bond0", "f8:75:a4:a4:00:fd", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.21/24", "192.168.6.10/20", "fe80::d832:8def:dd51:3529/125"}, false, true, false, -1),
-			newFilledInterfaceMock(1400, "eth2.10", "f8:75:a4:a4:00:fc", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.25/24", "192.168.6.14/20", "fe80::d832:8def:dd51:3520/125"}, false, false, true, -1),
+			newFilledInterfaceMock(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "192.168.6.7/20", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, true, false, false, 100),
+			newFilledInterfaceMock(1400, "eth1", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.19/24", "192.168.6.8/20", "fe80::d832:8def:dd51:3528/127", "de90::d832:8def:dd51:3528/127"}, true, false, false, 10),
+			newFilledInterfaceMock(1400, "eth2", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.20/24", "192.168.6.9/20", "fe80::d832:8def:dd51:3529/126", "de90::d832:8def:dd51:3529/126"}, false, false, false, 5),
+			newFilledInterfaceMock(1400, "bond0", "f8:75:a4:a4:00:fd", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.21/24", "192.168.6.10/20", "fe80::d832:8def:dd51:3529/125", "de90::d832:8def:dd51:3529/125"}, false, true, false, -1),
+			newFilledInterfaceMock(1400, "eth2.10", "f8:75:a4:a4:00:fc", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.25/24", "192.168.6.14/20", "fe80::d832:8def:dd51:3520/125", "de90::d832:8def:dd51:3520/125"}, false, false, true, -1),
 		}
 		dependencies.On("Interfaces").Return(rets, nil).Once()
 		dependencies.On("Execute", "biosdevname", "-i", "eth0").Return("em2", "", 0).Once()
@@ -140,7 +140,7 @@ var _ = Describe("Interfaces", func() {
 		dependencies.On("LinkByName", mock.Anything).Return(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}, nil)
 		dependencies.On("RouteList", mock.Anything, mock.Anything).Return([]netlink.Route{
 			{
-				Dst:      &net.IPNet{IP: net.ParseIP("fe80::"), Mask: net.CIDRMask(62, 128)},
+				Dst:      &net.IPNet{IP: net.ParseIP("de90::"), Mask: net.CIDRMask(62, 128)},
 				Protocol: unix.RTPROT_RA,
 			},
 		}, nil)
@@ -153,7 +153,7 @@ var _ = Describe("Interfaces", func() {
 				Flags:         []string{"up", "broadcast"},
 				HasCarrier:    false,
 				IPV4Addresses: []string{"10.0.0.18/24", "192.168.6.7/20"},
-				IPV6Addresses: []string{"fe80::d832:8def:dd51:3527/62"},
+				IPV6Addresses: []string{"de90::d832:8def:dd51:3527/62"},
 				MacAddress:    "f8:75:a4:a4:00:fe",
 				Mtu:           1500,
 				Name:          "eth0",
@@ -167,7 +167,7 @@ var _ = Describe("Interfaces", func() {
 				Flags:         []string{"broadcast", "loopback"},
 				HasCarrier:    false,
 				IPV4Addresses: []string{"10.0.0.19/24", "192.168.6.8/20"},
-				IPV6Addresses: []string{"fe80::d832:8def:dd51:3528/62"},
+				IPV6Addresses: []string{"de90::d832:8def:dd51:3528/62"},
 				MacAddress:    "f8:75:a4:a4:00:ff",
 				Mtu:           1400,
 				Name:          "eth1",
@@ -182,7 +182,7 @@ var _ = Describe("Interfaces", func() {
 				HasCarrier:    false,
 				IPV4Addresses: []string{"10.0.0.21/24", "192.168.6.10/20"},
 				IPV6Addresses: []string{
-					"fe80::d832:8def:dd51:3529/62",
+					"de90::d832:8def:dd51:3529/62",
 				},
 				MacAddress: "f8:75:a4:a4:00:fd",
 				Mtu:        1400,
@@ -198,7 +198,7 @@ var _ = Describe("Interfaces", func() {
                                 HasCarrier:    false,
                                 IPV4Addresses: []string{"10.0.0.25/24", "192.168.6.14/20"},
                                 IPV6Addresses: []string{
-                                        "fe80::d832:8def:dd51:3520/62",
+                                        "de90::d832:8def:dd51:3520/62",
                                 },
                                 MacAddress: "f8:75:a4:a4:00:fc",
                                 Mtu:        1400,


### PR DESCRIPTION
    all the ipv6 addresses starting with "fe80" are local link ones and
    should be filtered out from the inventory result cause they are not
    routable