### PR TITLE
MGMT-6668 Invalidate agent cache when there is a problem to perform get next steps from assisted service

### DIFF
--- a/src/commands/reply_cache.go
+++ b/src/commands/reply_cache.go
@@ -9,7 +9,11 @@ import (
 	"github.com/thoas/go-funk"
 )
 
-var replyCache = cache.New(time.Hour, time.Hour)
+var replyCache = newCache()
+
+func newCache() *cache.Cache {
+	return cache.New(time.Hour, time.Hour)
+}
 
 func alreadyExistsInService(stepType models.StepType, value string) bool {
 	storedValue, ok := replyCache.Get(string(stepType))
@@ -18,4 +22,8 @@ func alreadyExistsInService(stepType models.StepType, value string) bool {
 
 func storeInCache(stepType models.StepType, value string) {
 	replyCache.Set(string(stepType), value, cache.DefaultExpiration)
+}
+
+func invalidateCache() {
+	replyCache.Flush()
 }

--- a/src/commands/step_processor.go
+++ b/src/commands/step_processor.go
@@ -116,6 +116,7 @@ func (s *stepSession) processSingleSession() (int64, string) {
 	s.Logger().Info("Query for next steps")
 	result, err := s.Client().Installer.GetNextSteps(s.Context(), &params)
 	if err != nil {
+		invalidateCache()
 		switch errValue := err.(type) {
 		case *installer.GetNextStepsNotFound:
 			s.Logger().WithError(err).Errorf("Cluster %s was not found in inventory or user is not authorized, going to sleep forever", params.ClusterID)


### PR DESCRIPTION


- Since some of the messages are cleared from host database row when agent disconnects, it is essential to invalidate the cache such case
- Since the cache is needed for optimization only, it will not harm the system functionality

/cc @tsorya 