### PR TITLE
[WIP] OCPBUGSM-30255: Add more descriptive error for HTTP 503

### DIFF
--- a/src/commands/register_node.go
+++ b/src/commands/register_node.go
@@ -63,6 +63,8 @@ func RegisterHostWithRetry() *models.HostRegistrationResponseAO1NextStepRunnerCo
 			s.Logger().Warnf("Error registering host: %s, %s", http.StatusText(http.StatusInternalServerError), swag.StringValue(errValue.Payload.Reason))
 		case *installer.RegisterHostBadRequest:
 			s.Logger().Warnf("Error registering host: %s, %s", http.StatusText(http.StatusBadRequest), swag.StringValue(errValue.Payload.Reason))
+		case *installer.RegisterHostServiceUnavailable:
+			s.Logger().Warnf("Error registering host: %s. Make sure the assisted-service is available", http.StatusText(http.StatusServiceUnavailable))
 		default:
 			s.Logger().WithError(err).Warn("Error registering host")
 		}


### PR DESCRIPTION
# Description

When the agent tries to perform the call-home procedure and for any
reason the assisted-service pod is not reachable, OpenShift Router will
return HTTP 503 Service Unavailable error. In such a scenario we want
the operator to see a descriptive error message instead of the currently
shown

```
level=warning msg="Error registering host" file="register_node.go:67" error="&{<nil> <nil> <nil> <nil> <nil>} (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface" request_id=39d30f2f-5c60-4857-b69a-a044f3e398cf
```

This PR adds an additional case statement to handle HTTP 503 error.

Closes: [OCPBUGSM-30255](https://issues.redhat.com/browse/OCPBUGSM-30255)

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

# Assignees

/assign 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
