### PR TITLE
MGMT-6498: Fixes empty slice capturing the default route

### DIFF
--- a/src/inventory/routes_test.go
+++ b/src/inventory/routes_test.go
@@ -17,29 +17,11 @@ type netPair struct {
 }
 
 var (
-	gwFirst = netPair{
+	ipV4GW = netPair{
 		routes: []netlink.Route{
-			{LinkIndex: 0, Dst: &net.IPNet{IP: net.IPv4zero}, Gw: net.IPv4(10, 254, 0, 1)},
-			{LinkIndex: 1, Dst: &net.IPNet{IP: net.IPv4(10, 254, 0, 0)}, Gw: net.IPv4zero},
-			{LinkIndex: 2, Dst: &net.IPNet{IP: net.IPv4(172, 17, 0, 0)}, Gw: net.IPv4zero},
-			{LinkIndex: 3, Dst: &net.IPNet{IP: net.IPv4(192, 168, 122, 0)}, Gw: net.IPv4zero}},
-		linkNames: []string{"eth3", "eth3", "docker0", "virbr0"}}
-	gwLast = netPair{
-		routes: []netlink.Route{
-			{LinkIndex: 0, Dst: &net.IPNet{IP: net.IPv4(10, 254, 0, 0)}, Gw: net.IPv4zero},
-			{LinkIndex: 1, Dst: &net.IPNet{IP: net.IPv4(172, 17, 0, 0)}, Gw: net.IPv4zero},
-			{LinkIndex: 2, Dst: &net.IPNet{IP: net.IPv4(192, 168, 122, 0)}, Gw: net.IPv4zero},
-			{LinkIndex: 3, Dst: &net.IPNet{IP: net.IPv4zero}, Gw: net.IPv4(10, 254, 0, 1)}},
-		linkNames: []string{"eth3", "docker0", "virbr0", "eth3"},
-	}
-	gwMiddle = netPair{
-		routes: []netlink.Route{
-			{LinkIndex: 0, Dst: &net.IPNet{IP: net.IPv4(10, 254, 0, 0)}, Gw: net.IPv4zero},
-			{LinkIndex: 1, Dst: &net.IPNet{IP: net.IPv4(172, 17, 0, 0)}, Gw: net.IPv4zero},
-			{LinkIndex: 3, Dst: &net.IPNet{IP: net.IPv4zero}, Gw: net.IPv4(10, 254, 0, 1)},
-			{LinkIndex: 2, Dst: &net.IPNet{IP: net.IPv4(192, 168, 122, 0)}, Gw: net.IPv4zero}},
-		linkNames: []string{"eth3", "docker0", "eth3", "virbr0"},
-	}
+			{LinkIndex: 0, Dst: nil, Gw: net.IPv4(10, 254, 0, 1)},
+			{LinkIndex: 1, Dst: &net.IPNet{IP: net.IPv4(192, 168, 122, 0)}, Gw: net.IPv4zero}},
+		linkNames: []string{"eth3", "virbr0"}}
 
 	noInternetConnection = netPair{
 		routes: []netlink.Route{
@@ -53,7 +35,7 @@ var (
 		linkNames: []string{},
 	}
 
-	v6GWFirst = netPair{
+	ipV6GW = netPair{
 		routes: []netlink.Route{
 			{LinkIndex: 0, Gw: net.ParseIP("2001:1::1"), Dst: &net.IPNet{IP: net.IPv6zero}},
 			{LinkIndex: 1, Gw: net.IPv6zero, Dst: &net.IPNet{IP: net.ParseIP("2001:2::1")}},
@@ -61,24 +43,6 @@ var (
 		linkNames: []string{"eth3", "eth3", "lo"},
 	}
 
-	v6GWLast = netPair{
-		routes: []netlink.Route{
-			{LinkIndex: 0, Gw: net.IPv6zero, Dst: &net.IPNet{IP: net.ParseIP("2001:2::1")}},
-			{LinkIndex: 1, Gw: net.IPv6zero, Dst: &net.IPNet{IP: net.IPv6zero}},
-			{LinkIndex: 2, Gw: net.ParseIP("2001:1::1"), Dst: &net.IPNet{IP: net.IPv6zero}}},
-		linkNames: []string{"eth3", "lo", "eth3"},
-	}
-
-	v6GWMiddle = netPair{
-		routes: []netlink.Route{
-			{LinkIndex: 0, Gw: net.IPv6zero, Dst: &net.IPNet{IP: net.ParseIP("2001:2::1")}},
-			{LinkIndex: 1, Gw: net.ParseIP("2001:1::1"), Dst: &net.IPNet{IP: net.IPv6zero}},
-			{LinkIndex: 2, Gw: net.IPv6zero, Dst: &net.IPNet{IP: net.IPv6zero}}},
-		linkNames: []string{"eth3", "eth3", "lo"},
-	}
-)
-
-var (
 	ipv4Route = models.Route{Interface: "eth3", Gateway: "10.254.0.1", Family: int32(familyIPv4)}
 	ipv6Route = models.Route{Interface: "eth3", Gateway: net.ParseIP("2001:1::1").String(), Family: int32(familyIPv6)}
 )
@@ -125,28 +89,22 @@ var _ = Describe("Route test", func() {
 			expected   *models.Route
 			errStrFrag string
 		}{
-			{"should find the gateway first", testHandler{routes: gwFirst.routes, linkNames: gwFirst.linkNames, family: familyIPv4}, 1, &ipv4Route, ""},
-			{"should find the gateway in the middle", testHandler{routes: gwMiddle.routes, linkNames: gwMiddle.linkNames, family: familyIPv4}, 1, &ipv4Route, ""},
-			{"should find the gateway last", testHandler{routes: gwLast.routes, linkNames: gwLast.linkNames, family: familyIPv4}, 1, &ipv4Route, ""},
-			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv4}, 0, nil, ""},
-			{"should have no default routes", testHandler{routes: noInternetConnection.routes, linkNames: noInternetConnection.linkNames, family: familyIPv4}, 0, nil, ""},
+			{"should find all the routes when the default route is first", testHandler{routes: ipV4GW.routes, linkNames: ipV4GW.linkNames, family: familyIPv4}, len(ipV4GW.routes), &ipv4Route, ""},
+			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv4}, len(nothing.routes), nil, ""},
+			{"should have routes when no internet connection/default route", testHandler{routes: noInternetConnection.routes, linkNames: noInternetConnection.linkNames, family: familyIPv4}, len(noInternetConnection.routes), nil, ""},
 			{"should return error when retrieving routes", testHandler{errorRoutes: fmt.Errorf("cannot retrieve routes"), family: familyIPv4}, 0, nil, "cannot retrieve routes"},
-			{"should return error when retrieving link name", testHandler{routes: gwFirst.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: familyIPv4}, 0, nil, "cannot retrieve link name"},
+			{"should return error when retrieving link name", testHandler{routes: ipV4GW.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: familyIPv4}, 0, nil, "cannot retrieve link name"},
 		}
 
 		for _, tc := range testCases {
 			tc := tc
 			It(tc.name, func() {
-				routes, err := getIPDefaultRoutes(tc.handler)
+				routes, err := getIPRoutes(tc.handler)
 				if err != nil {
 					Expect(err.Error()).To(ContainSubstring(tc.errStrFrag))
 				} else {
 					Expect(tc.errStrFrag).To(BeEmpty())
 					Expect(tc.count).To(Equal(len(routes)))
-					if tc.count == 1 {
-						Expect(tc.expected.Gateway).To(Equal(routes[0].Gateway))
-						Expect(routes[0].Destination).To(Equal(net.IPv4zero.String()))
-					}
 				}
 			})
 		}
@@ -160,27 +118,21 @@ var _ = Describe("Route test", func() {
 			expected   *models.Route
 			errStrFrag string
 		}{
-			{"should find the gateway first", testHandler{routes: v6GWFirst.routes, linkNames: v6GWFirst.linkNames, family: familyIPv6}, 1, &ipv6Route, ""},
-			{"should find the gateway in the middle", testHandler{routes: v6GWMiddle.routes, linkNames: v6GWMiddle.linkNames, family: familyIPv6}, 1, &ipv6Route, ""},
-			{"should find the gateway last", testHandler{routes: v6GWLast.routes, linkNames: v6GWLast.linkNames, family: familyIPv6}, 1, &ipv6Route, ""},
-			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv6}, 0, nil, ""},
-			{"should have no default routes", testHandler{routes: noInternetConnection.routes, linkNames: noInternetConnection.linkNames, family: familyIPv6}, 0, nil, ""},
+			{"should find all the routes when the default route is first", testHandler{routes: ipV6GW.routes, linkNames: ipV6GW.linkNames, family: familyIPv6}, len(ipV6GW.routes), &ipv6Route, ""},
+			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv6}, len(nothing.routes), nil, ""},
+			{"should have routes when no internet connection/default route", testHandler{routes: noInternetConnection.routes, linkNames: noInternetConnection.linkNames, family: familyIPv6}, len(noInternetConnection.routes), nil, ""},
 			{"should return error when retrieving routes", testHandler{errorRoutes: fmt.Errorf("cannot retrieve routes"), family: familyIPv6}, 0, nil, "cannot retrieve routes"},
-			{"should return error when retrieving link name", testHandler{routes: v6GWFirst.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: familyIPv6}, 0, nil, "cannot retrieve link name"},
+			{"should return error when retrieving link name", testHandler{routes: ipV6GW.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: familyIPv6}, 0, nil, "cannot retrieve link name"},
 		}
 		for _, tc := range testCases {
 			tc := tc
 			It(tc.name, func() {
-				routes, err := getIPDefaultRoutes(tc.handler)
+				routes, err := getIPRoutes(tc.handler)
 				if err != nil {
 					Expect(err.Error()).To(ContainSubstring(tc.errStrFrag))
 				} else {
 					Expect(tc.errStrFrag).To(BeEmpty())
 					Expect(tc.count).To(Equal(len(routes)))
-					if tc.count == 1 {
-						Expect(tc.expected.Gateway).To(Equal(routes[0].Gateway))
-						Expect(routes[0].Destination).To(Equal(net.IPv6zero.String()))
-					}
 				}
 			})
 		}


### PR DESCRIPTION
While testing the assisted-service [PR](https://github.com/openshift/assisted-service/pull/1785) I noticed that the slice returning from the agent for the default route was always empty. I tested the logic locally using my own routing information and I detected that the value returned by the go library for the destination field is a nil, and in the current filtering logic it is expecting an IP of zero value (0.0.0.0 for IPv4 and equivalent for IPv6). 

This PR addresses this discrepancy by making sure that the filter now only takes into account routing entries where the Dst field is nil, or if it's not nil, then it is unspecified (== IP zero) in order to be considered a default route. 