### PR TITLE
NO-ISSUE Fix linting errors on ocm-2.3 branch

### DIFF
--- a/src/apivip_check/apivip_check.go
+++ b/src/apivip_check/apivip_check.go
@@ -133,14 +133,16 @@ func calculateMachineNetworkCIDR(apiVip net.IP, log logrus.FieldLogger) (string,
 		}
 
 		if !isVIPv4 {
-			util.SetV6PrefixesForAddress(intf.Name, &util.NetlinkRouteFinder{}, log, addrStrs)
+			if err := util.SetV6PrefixesForAddress(intf.Name, &util.NetlinkRouteFinder{}, log, addrStrs); err != nil {
+				log.WithError(err).Warnf("Failed to set V6 prefix for interface %s address %s", intf.Name, addrStrs)
+			}
 		}
 
 		for _, ipAddr := range addrStrs {
 
 			_, ipNet, err := net.ParseCIDR(ipAddr)
 			if err != nil {
-				log.WithError(err).Warnf("Error parsing CIDR: %s", err)
+				log.WithError(err).Warnf("Error parsing CIDR: %s", ipAddr)
 				continue
 			}
 

--- a/src/commands/connectivity_check_test.go
+++ b/src/commands/connectivity_check_test.go
@@ -356,7 +356,7 @@ var _ = Describe("parse ping command", func() {
 				Expect(err).To(BeNil())
 			}
 			Expect(conn.AverageRTTMs).Should(Equal(t.averageRTTMs))
-			Expect(conn.PacketLossPercentage).Should(Equal(float64(t.packetLoss)))
+			Expect(conn.PacketLossPercentage).Should(Equal(t.packetLoss))
 		})
 	}
 

--- a/src/disk_speed_check/disk_speed_check_test.go
+++ b/src/disk_speed_check/disk_speed_check_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Disk speed check test", func() {
 
 func getRequestStr(path string) string {
 	request := models.DiskSpeedCheckRequest{
-		Path:                swag.String(path),
+		Path: swag.String(path),
 	}
 
 	requestBytes, err := json.Marshal(request)

--- a/src/inventory/boot_test.go
+++ b/src/inventory/boot_test.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/src/inventory/interfaces.go
+++ b/src/inventory/interfaces.go
@@ -43,7 +43,7 @@ func (i *interfaces) getDeviceField(name, field string) string {
 
 func ipWithCidrInCidr(ipWithCidrStr, cidrStr string) bool {
 	ip, _, err := net.ParseCIDR(ipWithCidrStr)
-	if ip == nil {
+	if ip == nil || err != nil {
 		return false
 	}
 	_, ipnet, err := net.ParseCIDR(cidrStr)
@@ -140,6 +140,8 @@ func setV6PrefixesForAddresses(interfaces []*models.Interface, dependencies util
 			continue
 		}
 
-		util.SetV6PrefixesForAddress(intf.Name, dependencies, logrus.StandardLogger(), intf.IPV6Addresses)
+		if err := util.SetV6PrefixesForAddress(intf.Name, dependencies, logrus.StandardLogger(), intf.IPV6Addresses); err != nil {
+			logrus.WithError(err).Warnf("Failed to set V6 prefix for interface %s address %s", intf.Name, intf.IPV6Addresses)
+		}
 	}
 }

--- a/src/inventory/interfaces_test.go
+++ b/src/inventory/interfaces_test.go
@@ -192,21 +192,21 @@ var _ = Describe("Interfaces", func() {
 				Vendor:     "my-vendor2",
 			},
 			{
-                                Biosdevname:   "vlan",
-                                ClientID:      "",
-                                Flags:         []string{"up", "broadcast"},
-                                HasCarrier:    false,
-                                IPV4Addresses: []string{"10.0.0.25/24", "192.168.6.14/20"},
-                                IPV6Addresses: []string{
-                                        "de90::d832:8def:dd51:3520/62",
-                                },
-                                MacAddress: "f8:75:a4:a4:00:fc",
-                                Mtu:        1400,
-                                Name:       "eth2.10",
-                                Product:    "",
-                                SpeedMbps:  -1,
-                                Vendor:     "my-vendor2",
-                        },
+				Biosdevname:   "vlan",
+				ClientID:      "",
+				Flags:         []string{"up", "broadcast"},
+				HasCarrier:    false,
+				IPV4Addresses: []string{"10.0.0.25/24", "192.168.6.14/20"},
+				IPV6Addresses: []string{
+					"de90::d832:8def:dd51:3520/62",
+				},
+				MacAddress: "f8:75:a4:a4:00:fc",
+				Mtu:        1400,
+				Name:       "eth2.10",
+				Product:    "",
+				SpeedMbps:  -1,
+				Vendor:     "my-vendor2",
+			},
 		}))
 		for _, i := range rets {
 			i.(*MockInterface).AssertExpectations(GinkgoT())

--- a/src/util/network_interface.go
+++ b/src/util/network_interface.go
@@ -1,6 +1,6 @@
 package util
 
-import(
+import (
 	"fmt"
 	"net"
 	"strconv"
@@ -11,76 +11,76 @@ import(
 
 //go:generate mockery -name Interface -inpkg
 type Interface interface {
-        MTU() int
-        Name() string
-        HardwareAddr() net.HardwareAddr
-        Flags() net.Flags
-        Addrs() ([]net.Addr, error)
-        IsPhysical() bool
-        IsBonding() bool
-        IsVlan() bool
-        SpeedMbps() int64
+	MTU() int
+	Name() string
+	HardwareAddr() net.HardwareAddr
+	Flags() net.Flags
+	Addrs() ([]net.Addr, error)
+	IsPhysical() bool
+	IsBonding() bool
+	IsVlan() bool
+	SpeedMbps() int64
 }
 
 type NetworkInterface struct {
-        netInterface net.Interface
-        dependencies IDependencies
+	netInterface net.Interface
+	dependencies IDependencies
 }
 
 func (n *NetworkInterface) MTU() int {
-        return n.netInterface.MTU
+	return n.netInterface.MTU
 }
 
 func (n *NetworkInterface) Name() string {
-        return n.netInterface.Name
+	return n.netInterface.Name
 }
 
 func (n *NetworkInterface) HardwareAddr() net.HardwareAddr {
-        return n.netInterface.HardwareAddr
+	return n.netInterface.HardwareAddr
 }
 
 func (n *NetworkInterface) Flags() net.Flags {
-        return n.netInterface.Flags
+	return n.netInterface.Flags
 }
 
 func (n *NetworkInterface) Addrs() ([]net.Addr, error) {
-        return n.netInterface.Addrs()
+	return n.netInterface.Addrs()
 }
 
 func (n *NetworkInterface) IsPhysical() bool {
-        evaledPath, err := n.dependencies.EvalSymlinks(fmt.Sprintf("/sys/class/net/%s", n.netInterface.Name))
-        if err != nil {
-                logrus.WithError(err).Warnf("Could not determine if interface %s is physical", n.netInterface.Name)
-                return true
-        }
-        return !strings.Contains(evaledPath, "/virtual/")
+	evaledPath, err := n.dependencies.EvalSymlinks(fmt.Sprintf("/sys/class/net/%s", n.netInterface.Name))
+	if err != nil {
+		logrus.WithError(err).Warnf("Could not determine if interface %s is physical", n.netInterface.Name)
+		return true
+	}
+	return !strings.Contains(evaledPath, "/virtual/")
 }
 
 func (n *NetworkInterface) IsBonding() bool {
-        link, err := n.dependencies.LinkByName(n.netInterface.Name)
-        if err != nil {
-                return false
-        }
-        return link.Type() == "bond"
+	link, err := n.dependencies.LinkByName(n.netInterface.Name)
+	if err != nil {
+		return false
+	}
+	return link.Type() == "bond"
 }
 
 func (n *NetworkInterface) IsVlan() bool {
-        link, err := n.dependencies.LinkByName(n.netInterface.Name)
-        if err != nil {
-                return false
-        }
-        return link.Type() == "vlan"
+	link, err := n.dependencies.LinkByName(n.netInterface.Name)
+	if err != nil {
+		return false
+	}
+	return link.Type() == "vlan"
 }
 
 func (n *NetworkInterface) SpeedMbps() int64 {
-        b, err := n.dependencies.ReadFile(fmt.Sprintf("/sys/class/net/%s/speed", n.Name()))
-        if err != nil {
-                logrus.WithError(err).Warnf("Could not read %s speed", n.Name())
-                return 0
-        }
-        ret, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 32)
-        if err != nil {
-                logrus.WithError(err).Warnf("Could not parse %s speed", n.Name())
-        }
-        return ret
+	b, err := n.dependencies.ReadFile(fmt.Sprintf("/sys/class/net/%s/speed", n.Name()))
+	if err != nil {
+		logrus.WithError(err).Warnf("Could not read %s speed", n.Name())
+		return 0
+	}
+	ret, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 32)
+	if err != nil {
+		logrus.WithError(err).Warnf("Could not parse %s speed", n.Name())
+	}
+	return ret
 }


### PR DESCRIPTION
Fixes the following errors from the linter:

```
lranjbar@localhost assisted-installer-agent]$ make lint
golangci-lint run -v --fix
INFO [config_reader] Config search paths: [./ /home/lranjbar/github/openshift/assisted-installer-agent /home/lranjbar/github/openshift /home/lranjbar/github /home/lranjbar /home /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 16 linters: [deadcode errcheck gocyclo gofmt goimports gosec gosimple govet ineffassign scopelint staticcheck structcheck typecheck unconvert unused varcheck] 
INFO [loader] Go packages loading at mode 575 (imports|name|types_sizes|compiled_files|deps|files|exports_file) took 533.592492ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 8.454188ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 67, after processing: 35 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 36/56, nolint: 36/36, cgo: 67/67, skip_files: 67/67, diff: 35/35, max_from_linter: 35/35, source_code: 35/35, filename_unadjuster: 67/67, autogenerated_exclude: 67/67, identifier_marker: 67/67, exclude: 56/67, uniq_by_line: 35/36, max_same_issues: 35/35, severity-rules: 35/35, sort_results: 35/35, skip_dirs: 67/67, max_per_file_from_linter: 35/35, path_shortener: 35/35, path_prefixer: 35/35, path_prettifier: 67/67 
INFO [runner] processing took 2.994871ms with stages: nolint: 1.29116ms, identifier_marker: 573.904µs, exclude-rules: 459.791µs, path_prettifier: 205.8µs, autogenerated_exclude: 146.215µs, source_code: 121.526µs, exclude: 92.756µs, skip_dirs: 77.279µs, cgo: 6.923µs, max_from_linter: 5.012µs, path_shortener: 4.389µs, max_same_issues: 2.92µs, uniq_by_line: 2.416µs, filename_unadjuster: 2.33µs, max_per_file_from_linter: 1.421µs, diff: 289ns, skip_files: 268ns, sort_results: 224ns, severity-rules: 162ns, path_prefixer: 86ns 
INFO [runner] linters took 132.976528ms with stages: goanalysis_metalinter: 129.050941ms, unused: 880.581µs 
INFO Line 195 has multiple issues but at least one of them is ranged: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"                                Biosdevname:   \"vlan\",", "                                ClientID:      \"\",", "                                Flags:         []string{\"up\", \"broadcast\"},", "                                HasCarrier:    false,", "                                IPV4Addresses: []string{\"10.0.0.25/24\", \"192.168.6.14/20\"},", "                                IPV6Addresses: []string{", "                                        \"de90::d832:8def:dd51:3520/62\",", "                                },", "                                MacAddress: \"f8:75:a4:a4:00:fc\",", "                                Mtu:        1400,", "                                Name:       \"eth2.10\",", "                                Product:    \"\",", "                                SpeedMbps:  -1,", "                                Vendor:     \"my-vendor2\",", "                        },"}, Replacement:(*result.Replacement)(0xc00098fdd0), Pkg:(*packages.Package)(0xc0019e87e0), LineRange:(*result.Range)(0xc0004392d0), Pos:token.Position{Filename:"src/inventory/interfaces_test.go", Offset:0, Line:195, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"                                Biosdevname:   \"vlan\",", "                                ClientID:      \"\",", "                                Flags:         []string{\"up\", \"broadcast\"},", "                                HasCarrier:    false,", "                                IPV4Addresses: []string{\"10.0.0.25/24\", \"192.168.6.14/20\"},", "                                IPV6Addresses: []string{", "                                        \"de90::d832:8def:dd51:3520/62\",", "                                },", "                                MacAddress: \"f8:75:a4:a4:00:fc\",", "                                Mtu:        1400,", "                                Name:       \"eth2.10\",", "                                Product:    \"\",", "                                SpeedMbps:  -1,", "                                Vendor:     \"my-vendor2\",", "                        },"}, Replacement:(*result.Replacement)(0xc00098fe30), Pkg:(*packages.Package)(0xc0019e87e0), LineRange:(*result.Range)(0xc000439300), Pos:token.Position{Filename:"src/inventory/interfaces_test.go", Offset:0, Line:195, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"                                Biosdevname:   \"vlan\",", "                                ClientID:      \"\",", "                                Flags:         []string{\"up\", \"broadcast\"},", "                                HasCarrier:    false,", "                                IPV4Addresses: []string{\"10.0.0.25/24\", \"192.168.6.14/20\"},", "                                IPV6Addresses: []string{", "                                        \"de90::d832:8def:dd51:3520/62\",", "                                },", "                                MacAddress: \"f8:75:a4:a4:00:fc\",", "                                Mtu:        1400,", "                                Name:       \"eth2.10\",", "                                Product:    \"\",", "                                SpeedMbps:  -1,", "                                Vendor:     \"my-vendor2\",", "                        },"}, Replacement:(*result.Replacement)(0xc00098fdd0), Pkg:(*packages.Package)(0xc0019e87e0), LineRange:(*result.Range)(0xc0004392d0), Pos:token.Position{Filename:"src/inventory/interfaces_test.go", Offset:0, Line:195, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {195 209} 
INFO Fix issue &result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"\t\"fmt\""}, Replacement:(*result.Replacement)(0xc00098fe00), Pkg:(*packages.Package)(0xc0019e87e0), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/inventory/boot_test.go", Offset:0, Line:4, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {4 4} 
INFO Line 69 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"\t\tPath:                swag.String(path),"}, Replacement:(*result.Replacement)(0xc00098f770), Pkg:(*packages.Package)(0xc0019aab40), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/disk_speed_check/disk_speed_check_test.go", Offset:0, Line:69, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"\t\tPath:                swag.String(path),"}, Replacement:(*result.Replacement)(0xc00098f7a0), Pkg:(*packages.Package)(0xc0019aab40), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/disk_speed_check/disk_speed_check_test.go", Offset:0, Line:69, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"\t\tPath:                swag.String(path),"}, Replacement:(*result.Replacement)(0xc00098f770), Pkg:(*packages.Package)(0xc0019aab40), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/disk_speed_check/disk_speed_check_test.go", Offset:0, Line:69, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {69 69} 
INFO Line 70 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"}"}, Replacement:(*result.Replacement)(0xc0004cfe30), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/mock.go", Offset:0, Line:70, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"}"}, Replacement:(*result.Replacement)(0xc000c522a0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/mock.go", Offset:0, Line:70, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"}"}, Replacement:(*result.Replacement)(0xc0004cfe30), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/mock.go", Offset:0, Line:70, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {70 70} 
INFO Line 3 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"import("}, Replacement:(*result.Replacement)(0xc0004cfe90), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:3, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"import("}, Replacement:(*result.Replacement)(0xc000c522d0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:3, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 31 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.MTU"}, Replacement:(*result.Replacement)(0xc0004cff80), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:31, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        return n.netInterface.MTU"}, Replacement:(*result.Replacement)(0xc000c524b0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:31, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 35 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.Name"}, Replacement:(*result.Replacement)(0xc0004cffb0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:35, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        return n.netInterface.Name"}, Replacement:(*result.Replacement)(0xc000c52540), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:35, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 60 has multiple issues but at least one of them is ranged: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        link, err := n.dependencies.LinkByName(n.netInterface.Name)", "        if err != nil {", "                return false", "        }", "        return link.Type() == \"bond\""}, Replacement:(*result.Replacement)(0xc000c521b0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3390), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:60, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        link, err := n.dependencies.LinkByName(n.netInterface.Name)", "        if err != nil {", "                return false", "        }", "        return link.Type() == \"bond\""}, Replacement:(*result.Replacement)(0xc000c52660), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3610), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:60, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 14 has multiple issues but at least one of them is ranged: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        MTU() int", "        Name() string", "        HardwareAddr() net.HardwareAddr", "        Flags() net.Flags", "        Addrs() ([]net.Addr, error)", "        IsPhysical() bool", "        IsBonding() bool", "        IsVlan() bool", "        SpeedMbps() int64"}, Replacement:(*result.Replacement)(0xc0004cfef0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d32c0), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:14, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        MTU() int", "        Name() string", "        HardwareAddr() net.HardwareAddr", "        Flags() net.Flags", "        Addrs() ([]net.Addr, error)", "        IsPhysical() bool", "        IsBonding() bool", "        IsVlan() bool", "        SpeedMbps() int64"}, Replacement:(*result.Replacement)(0xc000c52300), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3480), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:14, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 26 has multiple issues but at least one of them is ranged: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        netInterface net.Interface", "        dependencies IDependencies"}, Replacement:(*result.Replacement)(0xc0004cff20), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3300), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:26, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        netInterface net.Interface", "        dependencies IDependencies"}, Replacement:(*result.Replacement)(0xc000c52420), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3560), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:26, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 39 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.HardwareAddr"}, Replacement:(*result.Replacement)(0xc000c52000), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:39, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        return n.netInterface.HardwareAddr"}, Replacement:(*result.Replacement)(0xc000c52570), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:39, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 43 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.Flags"}, Replacement:(*result.Replacement)(0xc000c52060), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:43, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        return n.netInterface.Flags"}, Replacement:(*result.Replacement)(0xc000c525d0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:43, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 47 has multiple issues but at least one of them isn't inline: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.Addrs()"}, Replacement:(*result.Replacement)(0xc000c520c0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:47, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        return n.netInterface.Addrs()"}, Replacement:(*result.Replacement)(0xc000c52600), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:47, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 51 has multiple issues but at least one of them is ranged: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        evaledPath, err := n.dependencies.EvalSymlinks(fmt.Sprintf(\"/sys/class/net/%s\", n.netInterface.Name))", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not determine if interface %s is physical\", n.netInterface.Name)", "                return true", "        }", "        return !strings.Contains(evaledPath, \"/virtual/\")"}, Replacement:(*result.Replacement)(0xc000c52120), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3350), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:51, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        evaledPath, err := n.dependencies.EvalSymlinks(fmt.Sprintf(\"/sys/class/net/%s\", n.netInterface.Name))", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not determine if interface %s is physical\", n.netInterface.Name)", "                return true", "        }", "        return !strings.Contains(evaledPath, \"/virtual/\")"}, Replacement:(*result.Replacement)(0xc000c52630), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d35d0), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:51, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 68 has multiple issues but at least one of them is ranged: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        link, err := n.dependencies.LinkByName(n.netInterface.Name)", "        if err != nil {", "                return false", "        }", "        return link.Type() == \"vlan\""}, Replacement:(*result.Replacement)(0xc000c521e0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d33c0), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:68, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        link, err := n.dependencies.LinkByName(n.netInterface.Name)", "        if err != nil {", "                return false", "        }", "        return link.Type() == \"vlan\""}, Replacement:(*result.Replacement)(0xc000c526c0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3650), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:68, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Line 76 has multiple issues but at least one of them is ranged: []result.Issue{result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        b, err := n.dependencies.ReadFile(fmt.Sprintf(\"/sys/class/net/%s/speed\", n.Name()))", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not read %s speed\", n.Name())", "                return 0", "        }", "        ret, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 32)", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not parse %s speed\", n.Name())", "        }", "        return ret"}, Replacement:(*result.Replacement)(0xc000c52240), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3400), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:76, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}, result.Issue{FromLinter:"goimports", Text:"File is not `goimports`-ed", Severity:"", SourceLines:[]string{"        b, err := n.dependencies.ReadFile(fmt.Sprintf(\"/sys/class/net/%s/speed\", n.Name()))", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not read %s speed\", n.Name())", "                return 0", "        }", "        ret, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 32)", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not parse %s speed\", n.Name())", "        }", "        return ret"}, Replacement:(*result.Replacement)(0xc000c526f0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3690), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:76, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""}} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"import("}, Replacement:(*result.Replacement)(0xc0004cfe90), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:3, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {3 3} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        MTU() int", "        Name() string", "        HardwareAddr() net.HardwareAddr", "        Flags() net.Flags", "        Addrs() ([]net.Addr, error)", "        IsPhysical() bool", "        IsBonding() bool", "        IsVlan() bool", "        SpeedMbps() int64"}, Replacement:(*result.Replacement)(0xc0004cfef0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d32c0), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:14, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {14 22} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        netInterface net.Interface", "        dependencies IDependencies"}, Replacement:(*result.Replacement)(0xc0004cff20), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3300), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:26, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {26 27} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.MTU"}, Replacement:(*result.Replacement)(0xc0004cff80), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:31, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {31 31} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.Name"}, Replacement:(*result.Replacement)(0xc0004cffb0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:35, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {35 35} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.HardwareAddr"}, Replacement:(*result.Replacement)(0xc000c52000), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:39, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {39 39} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.Flags"}, Replacement:(*result.Replacement)(0xc000c52060), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:43, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {43 43} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        return n.netInterface.Addrs()"}, Replacement:(*result.Replacement)(0xc000c520c0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:47, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {47 47} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        evaledPath, err := n.dependencies.EvalSymlinks(fmt.Sprintf(\"/sys/class/net/%s\", n.netInterface.Name))", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not determine if interface %s is physical\", n.netInterface.Name)", "                return true", "        }", "        return !strings.Contains(evaledPath, \"/virtual/\")"}, Replacement:(*result.Replacement)(0xc000c52120), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3350), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:51, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {51 56} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        link, err := n.dependencies.LinkByName(n.netInterface.Name)", "        if err != nil {", "                return false", "        }", "        return link.Type() == \"bond\""}, Replacement:(*result.Replacement)(0xc000c521b0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3390), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:60, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {60 64} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        link, err := n.dependencies.LinkByName(n.netInterface.Name)", "        if err != nil {", "                return false", "        }", "        return link.Type() == \"vlan\""}, Replacement:(*result.Replacement)(0xc000c521e0), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d33c0), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:68, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {68 72} 
INFO Fix issue &result.Issue{FromLinter:"gofmt", Text:"File is not `gofmt`-ed with `-s`", Severity:"", SourceLines:[]string{"        b, err := n.dependencies.ReadFile(fmt.Sprintf(\"/sys/class/net/%s/speed\", n.Name()))", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not read %s speed\", n.Name())", "                return 0", "        }", "        ret, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 32)", "        if err != nil {", "                logrus.WithError(err).Warnf(\"Could not parse %s speed\", n.Name())", "        }", "        return ret"}, Replacement:(*result.Replacement)(0xc000c52240), Pkg:(*packages.Package)(0xc001a42360), LineRange:(*result.Range)(0xc0005d3400), Pos:token.Position{Filename:"src/util/network_interface.go", Offset:0, Line:76, Column:0}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:""} with range {76 85} 
INFO fixer took 1.735466ms with stages: all: 1.735466ms 
src/apivip_check/apivip_check.go:136:32: Error return value of `util.SetV6PrefixesForAddress` is not checked (errcheck)
			util.SetV6PrefixesForAddress(intf.Name, &util.NetlinkRouteFinder{}, log, addrStrs)
			                            ^
src/commands/connectivity_check_test.go:359:58: unnecessary conversion (unconvert)
			Expect(conn.PacketLossPercentage).Should(Equal(float64(t.packetLoss)))
			                                                      ^
src/inventory/interfaces.go:143:31: Error return value of `util.SetV6PrefixesForAddress` is not checked (errcheck)
		util.SetV6PrefixesForAddress(intf.Name, dependencies, logrus.StandardLogger(), intf.IPV6Addresses)
		                            ^
src/inventory/interfaces.go:45:9: ineffectual assignment to `err` (ineffassign)
	ip, _, err := net.ParseCIDR(ipWithCidrStr)
	       ^
INFO File cache stats: 8 entries of total size 41.1KiB 
INFO Memory: 8 samples, avg is 72.2MB, max is 72.6MB 
INFO Execution took 680.824755ms                  
make: *** [Makefile:27: lint] Error 1
```

Signed-off-by: Lisa Rashidi-Ranjbar <lranjbar@redhat.com>