### PR TITLE
MGMT-7113: [WIP] Added arm64 build to Makefile and Dockerfile

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -10,6 +10,7 @@ RUN go mod download
 COPY . .
 
 RUN make build
+RUN make build-arm64
 
 FROM quay.io/centos/centos:centos8
 RUN dnf install -y \
@@ -43,5 +44,7 @@ COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/container_image_availability /usr/bin/container_image_availability
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/domain_resolution /usr/bin/domain_resolution
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/disk_speed_check /usr/bin/disk_speed_check
+
+COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/arm64/ /usr/bin/
 
 COPY scripts/installer/* /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,16 @@ ci-lint:
 lint: ci-lint
 	golangci-lint run -v --fix
 
-.PHONY: build clean build-image push subsystem
+.PHONY: build build-arm64 clean build-image push subsystem
 build: build-agent build-connectivity_check build-inventory build-free_addresses build-logs_sender \
 	   build-dhcp_lease_allocate build-apivip_check build-next_step_runner build-ntp_synchronizer \
 	   build-container_image_availability build-domain_resolution build-disk_speed_check
 
 build-%: $(BIN) src/$* #lint
-	CGO_ENABLED=0 go build -o $(BIN)/$* src/$*/main/main.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -o ${BIN}/$*${FILE_POSTFIX} src/$*/main/main.go
+
+build-arm64:
+	$(MAKE) build GOOS=linux GOARCH=arm64 BIN=$(BIN)/arm64 FILE_POSTFIX=-arm64
 
 build-image: unit-test
 	docker build ${CONTAINER_BUILD_PARAMS} -f Dockerfile.assisted_installer_agent . -t $(ASSISTED_INSTALLER_AGENT)


### PR DESCRIPTION
* Makefile: added build-arm64 target for bulding arm64 binaries,
  add a proper postfix and output to build/arm64 folder.
* Dockerfile: Invoked build-arm64 target and copied binaries to /usr/bin