### PR TITLE
Bug 1980901: Parse GW nil as net zero

### DIFF
--- a/src/inventory/interfaces.go
+++ b/src/inventory/interfaces.go
@@ -56,7 +56,7 @@ func ipWithCidrInCidr(ipWithCidrStr, cidrStr string) bool {
 func analyzeAddress(addr net.Addr) (isIpv4 bool, addrStr string, err error) {
 	ipNet, ok := addr.(*net.IPNet)
 	if !ok {
-		return false, "", fmt.Errorf("Could not cast to *net.IPNet")
+		return false, "", fmt.Errorf("could not cast to *net.IPNet")
 	}
 	mask, _ := ipNet.Mask.Size()
 	addrStr = fmt.Sprintf("%s/%d", ipNet.IP.String(), mask)

--- a/src/inventory/routes.go
+++ b/src/inventory/routes.go
@@ -46,7 +46,6 @@ func getIPZero(family int) *net.IP {
 	}
 	return &net.IPv6zero
 }
-
 func GetRoutes(dependencies util.IDependencies) []*models.Route {
 
 	rh4 := routeHandler{family: familyIPv4}
@@ -78,16 +77,19 @@ func getIPRoutes(h handler) ([]*models.Route, error) {
 			logrus.Errorf("Unable to retrieve the link name for index %d: %s", r.LinkIndex, err)
 			return nil, err
 		}
-		var dst string
+		var dst, gw string
 		if r.Dst == nil {
 			dst = getIPZero(h.getFamily()).String()
 		} else {
 			dst = r.Dst.IP.String()
 		}
+		if r.Gw != nil {
+			gw = r.Gw.String()
+		}
 		routes = append(routes, &models.Route{
 			Interface:   linkName,
 			Destination: dst,
-			Gateway:     r.Gw.String(),
+			Gateway:     gw,
 			Family:      int32(h.getFamily()),
 		})
 	}

--- a/src/inventory/routes_test.go
+++ b/src/inventory/routes_test.go
@@ -23,7 +23,7 @@ var (
 			{LinkIndex: 1, Dst: &net.IPNet{IP: net.IPv4(192, 168, 122, 0)}, Gw: net.IPv4zero}},
 		linkNames: []string{"eth3", "virbr0"}}
 
-	noInternetConnection = netPair{
+	ipv4NoInternetConnection = netPair{
 		routes: []netlink.Route{
 			{LinkIndex: 0, Dst: &net.IPNet{IP: net.IPv4(10, 254, 0, 0)}, Gw: net.IPv4zero},
 			{LinkIndex: 1, Dst: &net.IPNet{IP: net.IPv4(172, 17, 0, 0)}, Gw: net.IPv4zero}},
@@ -43,8 +43,35 @@ var (
 		linkNames: []string{"eth3", "eth3", "lo"},
 	}
 
-	ipv4Route = models.Route{Interface: "eth3", Gateway: "10.254.0.1", Family: int32(familyIPv4)}
-	ipv6Route = models.Route{Interface: "eth3", Gateway: net.ParseIP("2001:1::1").String(), Family: int32(familyIPv6)}
+	ipv6NoInternetConnection = netPair{
+		routes: []netlink.Route{
+			{LinkIndex: 0, Dst: &net.IPNet{IP: net.ParseIP("fd2e:6f44:5dd8:5::9b87")}, Gw: net.IPv6zero},
+			{LinkIndex: 1, Dst: &net.IPNet{IP: net.ParseIP("fe80::5054:ff:fedd:a823")}, Gw: net.IPv6zero}},
+		linkNames: []string{"docker0", "virbr0"},
+	}
+	ipV6GWNil = netPair{
+		routes: []netlink.Route{
+			{LinkIndex: 0, Dst: nil, Gw: nil},
+		},
+		linkNames: []string{"eth3", "virbr0"},
+	}
+
+	ipv4Route = []*models.Route{
+		{Interface: "eth3", Gateway: "10.254.0.1", Destination: "0.0.0.0", Family: int32(familyIPv4)},
+		{Interface: "virbr0", Gateway: net.IPv4zero.String(), Destination: "192.168.122.0", Family: int32(familyIPv4)}}
+	ipv4RouteNoInternetConnection = []*models.Route{
+		{Destination: "10.254.0.0", Gateway: net.IPv4zero.String(), Interface: "docker0", Family: int32(familyIPv4)},
+		{Destination: "172.17.0.0", Gateway: net.IPv4zero.String(), Interface: "virbr0", Family: int32(familyIPv4)},
+	}
+	ipv6Route = []*models.Route{
+		{Interface: "eth3", Gateway: "2001:1::1", Destination: net.IPv6zero.String(), Family: int32(familyIPv6)},
+		{Interface: "eth3", Gateway: net.IPv6zero.String(), Destination: "2001:2::1", Family: int32(familyIPv6)},
+		{Interface: "lo", Gateway: net.IPv6zero.String(), Destination: net.IPv6zero.String(), Family: int32(familyIPv6)}}
+	ipv6RouteNoInternetConnection = []*models.Route{
+		{Destination: "fd2e:6f44:5dd8:5::9b87", Gateway: net.IPv6zero.String(), Interface: "docker0", Family: int32(familyIPv6)},
+		{Destination: "fe80::5054:ff:fedd:a823", Gateway: net.IPv6zero.String(), Interface: "virbr0", Family: int32(familyIPv6)},
+	}
+	ipv6RouteGWNil = []*models.Route{{Interface: "eth3", Gateway: "", Destination: net.IPv6zero.String(), Family: int32(familyIPv6)}}
 )
 
 type testHandler struct {
@@ -86,12 +113,12 @@ var _ = Describe("Route test", func() {
 			name       string
 			handler    handler
 			count      int
-			expected   *models.Route
+			expected   []*models.Route
 			errStrFrag string
 		}{
-			{"should find all the routes when the default route is first", testHandler{routes: ipV4GW.routes, linkNames: ipV4GW.linkNames, family: familyIPv4}, len(ipV4GW.routes), &ipv4Route, ""},
-			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv4}, len(nothing.routes), nil, ""},
-			{"should have routes when no internet connection/default route", testHandler{routes: noInternetConnection.routes, linkNames: noInternetConnection.linkNames, family: familyIPv4}, len(noInternetConnection.routes), nil, ""},
+			{"should find all the routes when the default route is first", testHandler{routes: ipV4GW.routes, linkNames: ipV4GW.linkNames, family: familyIPv4}, len(ipV4GW.routes), ipv4Route, ""},
+			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv4}, len(nothing.routes), []*models.Route{}, ""},
+			{"should have routes when no internet connection/default route", testHandler{routes: ipv4NoInternetConnection.routes, linkNames: ipv4NoInternetConnection.linkNames, family: familyIPv4}, len(ipv4NoInternetConnection.routes), ipv4RouteNoInternetConnection, ""},
 			{"should return error when retrieving routes", testHandler{errorRoutes: fmt.Errorf("cannot retrieve routes"), family: familyIPv4}, 0, nil, "cannot retrieve routes"},
 			{"should return error when retrieving link name", testHandler{routes: ipV4GW.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: familyIPv4}, 0, nil, "cannot retrieve link name"},
 		}
@@ -105,6 +132,7 @@ var _ = Describe("Route test", func() {
 				} else {
 					Expect(tc.errStrFrag).To(BeEmpty())
 					Expect(tc.count).To(Equal(len(routes)))
+					Expect(tc.expected).To(ContainElements(routes))
 				}
 			})
 		}
@@ -115,14 +143,15 @@ var _ = Describe("Route test", func() {
 			name       string
 			handler    handler
 			count      int
-			expected   *models.Route
+			expected   []*models.Route
 			errStrFrag string
 		}{
-			{"should find all the routes when the default route is first", testHandler{routes: ipV6GW.routes, linkNames: ipV6GW.linkNames, family: familyIPv6}, len(ipV6GW.routes), &ipv6Route, ""},
+			{"should find all the routes when the default route is first", testHandler{routes: ipV6GW.routes, linkNames: ipV6GW.linkNames, family: familyIPv6}, len(ipV6GW.routes), ipv6Route, ""},
 			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv6}, len(nothing.routes), nil, ""},
-			{"should have routes when no internet connection/default route", testHandler{routes: noInternetConnection.routes, linkNames: noInternetConnection.linkNames, family: familyIPv6}, len(noInternetConnection.routes), nil, ""},
+			{"should have routes when no internet connection/default route", testHandler{routes: ipv6NoInternetConnection.routes, linkNames: ipv6NoInternetConnection.linkNames, family: familyIPv6}, len(ipv6NoInternetConnection.routes), ipv6RouteNoInternetConnection, ""},
 			{"should return error when retrieving routes", testHandler{errorRoutes: fmt.Errorf("cannot retrieve routes"), family: familyIPv6}, 0, nil, "cannot retrieve routes"},
 			{"should return error when retrieving link name", testHandler{routes: ipV6GW.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: familyIPv6}, 0, nil, "cannot retrieve link name"},
+			{"should have a route when gateway is nil", testHandler{routes: ipV6GWNil.routes, linkNames: ipV6GWNil.linkNames, family: familyIPv6}, len(ipV6GWNil.routes), ipv6RouteGWNil, ""},
 		}
 		for _, tc := range testCases {
 			tc := tc
@@ -133,6 +162,7 @@ var _ = Describe("Route test", func() {
 				} else {
 					Expect(tc.errStrFrag).To(BeEmpty())
 					Expect(tc.count).To(Equal(len(routes)))
+					Expect(tc.expected).To(ContainElements(routes))
 				}
 			})
 		}


### PR DESCRIPTION
When the GW is returned as `nil` from the agent, it is populated as garbage (`<nil>`) in the json, instead of containing a properly formatted IP. This causes the validation in the service to dump error log messages as it is unable to parse the GW value. 

This fix tackles the parsing part from the agent side, and sends an empty string value when it detects the value of the Gateway is nil.

There is a counterpart PR for the service to handle this use case:

https://github.com/openshift/assisted-service/pull/2223

I also enhanced the unit tests to check that the contents of the processed routes match as expected.

@ori-amizur can you take a look at this PR when you have some time?