### PR TITLE
MGMT-7383: Add v2 APIs to agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ unit-test:
 	$(MAKE) _test TEST_SCENARIO=unit TIMEOUT=30m TEST="$(or $(TEST),$(shell go list ./... | grep -v subsystem))" || (docker kill postgres && /bin/false)
 
 subsystem: build-image
+	-docker image rm subsystem_agent
 	$(DOCKER_COMPOSE) up --build -d dhcpd wiremock
 	-$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=30m TEST="$(or $(TEST),./subsystem/...)"
 	$(DOCKER_COMPOSE) logs dhcpd > dhcpd.log

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/jaypipes/ghw v0.7.0
 	github.com/jaypipes/pcidb v0.6.0
-	github.com/onsi/ginkgo v1.16.2
+	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.12.0
-	github.com/openshift/assisted-service v1.0.10-0.20210603130323-8a9f14ef82d4
+	github.com/openshift/assisted-service v1.0.10-0.20210726144421-e809201cb80d
 	github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -23,8 +23,9 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/thoas/go-funk v0.8.0
 	github.com/vishvananda/netlink v1.1.0
-	golang.org/x/sys v0.0.0-20210423082822-04245dca01da
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/kubectl v0.20.5 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -953,6 +953,8 @@ github.com/onsi/ginkgo v1.15.0 h1:1V1NfVQR87RtWAgp1lv9JZJ5Jap+XFGKPi00andXGi4=
 github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
 github.com/onsi/ginkgo v1.16.2 h1:HFB2fbVIlhIfCfOW81bZFbiC/RvnpXSdhbF2/DJr134=
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -991,6 +993,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.165 h1:NndMhSbJzTsBgZuoIgDhHHmk6pgF9
 github.com/openshift-online/ocm-sdk-go v0.1.165/go.mod h1:/DStCZJQ2XOV/ktkODyVnUCPnGfH3agwp0e+GZTLr3E=
 github.com/openshift-online/ocm-sdk-go v0.1.180 h1:PUdWZ8sgtIZ1V7JQBJqEj3MZc4CJZJUgWS9n7NZHg8s=
 github.com/openshift-online/ocm-sdk-go v0.1.180/go.mod h1:XpupkiWFXkiAPdgS8Dq7Gknk2E6AximJnpC98Hk4fl4=
+github.com/openshift-online/ocm-sdk-go v0.1.190 h1:GKQbhOeNIHNVQGBAPKhzPyUTrKKatz2j4d4AU2DNnJQ=
+github.com/openshift-online/ocm-sdk-go v0.1.190/go.mod h1:XpupkiWFXkiAPdgS8Dq7Gknk2E6AximJnpC98Hk4fl4=
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/api v0.0.0-20200424083944-0422dc17083e/go.mod h1:VnbEzX8SAaRj7Yfl836NykdQIlbEjfL6/CD+AaJQg5Q=
@@ -1005,6 +1009,8 @@ github.com/openshift/assisted-service v1.0.10-0.20210527145613-b4d6a5047a78 h1:g
 github.com/openshift/assisted-service v1.0.10-0.20210527145613-b4d6a5047a78/go.mod h1:Ch2auiFOWB9A3dJWZx21XafAsKHVaaQpfMkJxU5Uxus=
 github.com/openshift/assisted-service v1.0.10-0.20210603130323-8a9f14ef82d4 h1:wegedap83JSv+jXmGPJc8hqk69TeRR8YbNmU5anWuGc=
 github.com/openshift/assisted-service v1.0.10-0.20210603130323-8a9f14ef82d4/go.mod h1:Ch2auiFOWB9A3dJWZx21XafAsKHVaaQpfMkJxU5Uxus=
+github.com/openshift/assisted-service v1.0.10-0.20210726144421-e809201cb80d h1:DaUbbAaa6AAkWAC8XcPzVj/LJUjcGfg3wRJ4vX844cU=
+github.com/openshift/assisted-service v1.0.10-0.20210726144421-e809201cb80d/go.mod h1:vSBDraaHKwtryUMjiTbYhbKTNbC2VMN2udSaNtcwBjo=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd h1:5JV3JearFzKVj+bmc0PPrb1+bbgSye6loMQihlc3JBY=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd/go.mod h1:+duukQisb5LU1bMtLalsHZc1wM69D5sH3TuiyvAQhhA=
@@ -1097,6 +1103,7 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/pquerna/ffjson v0.0.0-20181028064349-e517b90714f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/pquerna/ffjson v0.0.0-20190813045741-dac163c6c0a9/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.49.0/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
 github.com/prometheus/alertmanager v0.18.0/go.mod h1:WcxHBl40VSPuOaqWae6l6HpnEOVRIycEJ7i9iYkadEE=
 github.com/prometheus/alertmanager v0.20.0/go.mod h1:9g2i48FAyZW6BtbsnvHtMHQXl2aVtrORKwKVCQ+nbrg=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -1317,6 +1324,7 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -1439,6 +1447,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1497,6 +1506,7 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/Lt
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1516,6 +1526,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1609,8 +1620,12 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
@@ -1711,6 +1726,7 @@ golang.org/x/tools v0.0.0-20200610160956-3e83d1e96d0e/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1894,6 +1910,7 @@ k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdB
 k8s.io/apiextensions-apiserver v0.17.3/go.mod h1:CJbCyMfkKftAd/X/V6OTHYhVn7zXnDdnkUjS1h0GTeY=
 k8s.io/apiextensions-apiserver v0.17.4/go.mod h1:rCbbbaFS/s3Qau3/1HbPlHblrWpFivoaLYccCffvQGI=
 k8s.io/apiextensions-apiserver v0.18.2/go.mod h1:q3faSnRGmYimiocj6cHQ1I3WpLqmDgJFlKL37fC4ZvY=
+k8s.io/apiextensions-apiserver v0.18.3/go.mod h1:TMsNGs7DYpMXd+8MOCX8KzPOCx8fnZMoIGB24m03+JE=
 k8s.io/apiextensions-apiserver v0.18.6/go.mod h1:lv89S7fUysXjLZO7ke783xOwVTm6lKizADfvUM/SS/M=
 k8s.io/apiextensions-apiserver v0.19.0/go.mod h1:znfQxNpjqz/ZehvbfMg5N6fvBJW5Lqu5HVLTJQdP4Fs=
 k8s.io/apiextensions-apiserver v0.19.2/go.mod h1:EYNjpqIAvNZe+svXVx9j4uBaVhTB4C94HkY3w058qcg=
@@ -1906,6 +1923,7 @@ k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/apiserver v0.17.3/go.mod h1:iJtsPpu1ZpEnHaNawpSV0nYTGBhhX2dUlnn7/QS7QiY=
 k8s.io/apiserver v0.17.4/go.mod h1:5ZDQ6Xr5MNBxyi3iUZXS84QOhZl+W7Oq2us/29c0j9I=
 k8s.io/apiserver v0.18.2/go.mod h1:Xbh066NqrZO8cbsoenCwyDJ1OSi8Ag8I2lezeHxzwzw=
+k8s.io/apiserver v0.18.3/go.mod h1:tHQRmthRPLUtwqsOnJJMoI8SW3lnoReZeE861lH8vUw=
 k8s.io/apiserver v0.18.6/go.mod h1:Zt2XvTHuaZjBz6EFYzpp+X4hTmgWGy8AthNVnTdm3Wg=
 k8s.io/apiserver v0.19.0/go.mod h1:XvzqavYj73931x7FLtyagh8WibHpePJ1QwWrSJs2CLk=
 k8s.io/apiserver v0.19.2/go.mod h1:FreAq0bJ2vtZFj9Ago/X0oNGC51GfubKK/ViOKfVAOA=
@@ -1929,6 +1947,7 @@ k8s.io/code-generator v0.17.4/go.mod h1:l8BLVwASXQZTo2xamW5mQNFCe1XPiAesVq7Y1t7P
 k8s.io/code-generator v0.18.0-rc.1/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
 k8s.io/code-generator v0.18.0/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
 k8s.io/code-generator v0.18.2/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
+k8s.io/code-generator v0.18.3/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
 k8s.io/code-generator v0.18.6/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
 k8s.io/code-generator v0.19.0/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
 k8s.io/code-generator v0.19.2/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
@@ -1942,6 +1961,7 @@ k8s.io/component-base v0.17.3/go.mod h1:GeQf4BrgelWm64PXkIXiPh/XS0hnO42d9gx9BtbZ
 k8s.io/component-base v0.17.4/go.mod h1:5BRqHMbbQPm2kKu35v3G+CpVq4K0RJKC7TRioF0I9lE=
 k8s.io/component-base v0.18.0-rc.1/go.mod h1:NNlRaxZEdLqTs2+6yXiU2SHl8gKsbcy19Ii+Sfq53RM=
 k8s.io/component-base v0.18.2/go.mod h1:kqLlMuhJNHQ9lz8Z7V5bxUUtjFZnrypArGl58gmDfUM=
+k8s.io/component-base v0.18.3/go.mod h1:bp5GzGR0aGkYEfTj+eTY0AN/vXTgkJdQXjNTTVUaa3k=
 k8s.io/component-base v0.18.6/go.mod h1:knSVsibPR5K6EW2XOjEHik6sdU5nCvKMrzMt2D4In14=
 k8s.io/component-base v0.19.0/go.mod h1:dKsY8BxkA+9dZIAh2aWJLL/UdASFDNtGYTCItL4LM7Y=
 k8s.io/component-base v0.19.2/go.mod h1:g5LrsiTiabMLZ40AR6Hl45f088DevyGY+cCE2agEIVo=

--- a/src/commands/service_api.go
+++ b/src/commands/service_api.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/openshift/assisted-installer-agent/src/config"
+	"github.com/openshift/assisted-installer-agent/src/scanners"
+	"github.com/openshift/assisted-installer-agent/src/session"
+	"github.com/openshift/assisted-service/client/installer"
+	"github.com/openshift/assisted-service/models"
+)
+
+type serviceAPI interface {
+	RegisterHost(s *session.InventorySession) (*models.HostRegistrationResponse, error)
+	GetNextSteps(s *session.InventorySession) (*models.Steps, error)
+	PostStepReply(s *session.InventorySession, reply *models.StepReply) error
+}
+
+type v1ServiceAPI struct {}
+
+func (v *v1ServiceAPI) RegisterHost(s *session.InventorySession) (*models.HostRegistrationResponse, error) {
+	params := &installer.RegisterHostParams{
+		ClusterID:             strfmt.UUID(config.GlobalAgentConfig.ClusterID),
+		DiscoveryAgentVersion: &config.GlobalAgentConfig.AgentVersion,
+		NewHostParams: &models.HostCreateParams{
+			HostID:                scanners.ReadId(scanners.NewGHWSerialDiscovery()),
+			DiscoveryAgentVersion: config.GlobalAgentConfig.AgentVersion,
+		},
+	}
+
+	result, err := s.Client().Installer.RegisterHost(s.Context(), params)
+	if err != nil {
+		return nil, err
+	}
+	return result.Payload, nil
+}
+
+func (v *v1ServiceAPI) GetNextSteps(s *session.InventorySession) (*models.Steps, error) {
+	params := installer.GetNextStepsParams{
+		HostID:                strfmt.UUID(config.GlobalAgentConfig.HostID),
+		ClusterID:             strfmt.UUID(config.GlobalAgentConfig.ClusterID),
+		DiscoveryAgentVersion: &config.GlobalAgentConfig.AgentVersion,
+	}
+	result, err := s.Client().Installer.GetNextSteps(s.Context(), &params)
+	if err != nil {
+		return nil, err
+	}
+	return result.Payload, nil
+}
+
+func (v *v1ServiceAPI) PostStepReply(s *session.InventorySession, reply *models.StepReply) error {
+	params := installer.PostStepReplyParams{
+		HostID:                strfmt.UUID(config.GlobalAgentConfig.HostID),
+		ClusterID:             strfmt.UUID(config.GlobalAgentConfig.ClusterID),
+		DiscoveryAgentVersion: &config.GlobalAgentConfig.AgentVersion,
+		Reply:                 reply,
+	}
+
+	_, err := s.Client().Installer.PostStepReply(s.Context(), &params)
+	return err
+}
+
+type v2ServiceAPI struct {}
+
+func (v *v2ServiceAPI) RegisterHost(s *session.InventorySession) (*models.HostRegistrationResponse, error) {
+	params := &installer.V2RegisterHostParams{
+		InfraEnvID:            strfmt.UUID(config.GlobalAgentConfig.InfraEnvID),
+		DiscoveryAgentVersion: &config.GlobalAgentConfig.AgentVersion,
+		NewHostParams: &models.HostCreateParams{
+			HostID:                scanners.ReadId(scanners.NewGHWSerialDiscovery()),
+			DiscoveryAgentVersion: config.GlobalAgentConfig.AgentVersion,
+		},
+	}
+
+	result, err := s.Client().Installer.V2RegisterHost(s.Context(), params)
+	if err != nil {
+		return nil, err
+	}
+	return result.Payload, nil
+}
+
+func (v *v2ServiceAPI) GetNextSteps(s *session.InventorySession) (*models.Steps, error) {
+	params := installer.V2GetNextStepsParams{
+		HostID:                strfmt.UUID(config.GlobalAgentConfig.HostID),
+		InfraEnvID:            strfmt.UUID(config.GlobalAgentConfig.InfraEnvID),
+		DiscoveryAgentVersion: &config.GlobalAgentConfig.AgentVersion,
+	}
+	result, err := s.Client().Installer.V2GetNextSteps(s.Context(), &params)
+	if err != nil {
+		return nil, err
+	}
+	return result.Payload, nil
+}
+
+func (v *v2ServiceAPI) PostStepReply(s *session.InventorySession, reply *models.StepReply) error {
+	params := installer.V2PostStepReplyParams{
+		HostID:                strfmt.UUID(config.GlobalAgentConfig.HostID),
+		InfraEnvID:            strfmt.UUID(config.GlobalAgentConfig.InfraEnvID),
+		DiscoveryAgentVersion: &config.GlobalAgentConfig.AgentVersion,
+		Reply:                 reply,
+	}
+
+	_, err := s.Client().Installer.V2PostStepReply(s.Context(), &params)
+	return err
+}
+
+func newServiceAPI() serviceAPI {
+	if config.GlobalAgentConfig.V2 {
+		return &v2ServiceAPI{}
+	}
+	return &v1ServiceAPI{}
+} 

--- a/src/config/agent_config.go
+++ b/src/config/agent_config.go
@@ -14,6 +14,7 @@ var GlobalAgentConfig struct {
 	ConnectivityConfig
 	IntervalSecs int
 	HostID       string
+	V2           bool
 	LoggingConfig
 }
 
@@ -25,7 +26,8 @@ func printHelpAndExit() {
 func ProcessArgs() {
 	ret := &GlobalAgentConfig
 	flag.StringVar(&ret.TargetURL, "url", "", "The target URL, including a scheme and optionally a port (overrides the host and port arguments")
-	flag.StringVar(&ret.ClusterID, "cluster-id", "default-cluster", "The value of the cluster-id")
+	flag.StringVar(&ret.ClusterID, "cluster-id", "", "The value of the cluster-id")
+	flag.StringVar(&ret.InfraEnvID, "infra-env-id", "", "The value of infra-env-id")
 	flag.StringVar(&ret.AgentVersion, "agent-version", "", "Discovery agent version")
 	flag.IntVar(&ret.IntervalSecs, "interval", 60, "Interval between steps polling in seconds")
 	flag.BoolVar(&ret.JournalLogging, "with-journal-logging", true, "Use journal logging")
@@ -42,6 +44,16 @@ func ProcessArgs() {
 	if ret.TargetURL == "" {
 		log.Fatalf("Must provide a target URL")
 	}
+
+	if ret.ClusterID == "" && ret.InfraEnvID == "" {
+		log.Fatal("One of cluster-id, infra-env-id must be provided")
+	}
+
+	if ret.ClusterID != "" && ret.InfraEnvID != "" {
+		log.Fatal("Only one of cluster-id, infra-env-id must be provided")
+	}
+
+	ret.V2 = ret.InfraEnvID != ""
 
 	ret.PullSecretToken = os.Getenv("PULL_SECRET_TOKEN")
 	if ret.PullSecretToken == "" {

--- a/src/config/connectivity_config.go
+++ b/src/config/connectivity_config.go
@@ -4,6 +4,7 @@ package config
 type ConnectivityConfig struct {
 	TargetURL          string
 	ClusterID          string
+	InfraEnvID         string
 	AgentVersion       string
 	PullSecretToken    string
 	InsecureConnection bool

--- a/subsystem/agent_test.go
+++ b/subsystem/agent_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	ClusterID                     = "11111111-1111-1111-1111-111111111111"
+	InfraEnvID                     = "11111111-1111-1111-1111-111111111111"
 	defaultnextInstructionSeconds = int64(1)
 	waitForWiremockTimeout        = 60 * time.Second
 )
@@ -39,7 +39,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Happy flow", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -53,7 +53,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Next step runner fails - default delay", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStubInvalidCommand(hostID, http.StatusCreated, ClusterID, -1)
+		registerStubID, err := addRegisterStubInvalidCommand(hostID, http.StatusCreated, InfraEnvID, -1)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -70,7 +70,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Next step runner keeps failing - retry registration", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStubInvalidCommand(hostID, http.StatusCreated, ClusterID, 3)
+		registerStubID, err := addRegisterStubInvalidCommand(hostID, http.StatusCreated, InfraEnvID, 3)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -87,7 +87,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Next step runner fails once, retry succeeds", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStubInvalidCommand(hostID, http.StatusCreated, ClusterID, 5)
+		registerStubID, err := addRegisterStubInvalidCommand(hostID, http.StatusCreated, InfraEnvID, 5)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("Agent tests", func() {
 		verifyNumberOfGetNextRequest(hostID, "==", 0)
 		Expect(deleteStub(registerStubID)).NotTo(HaveOccurred())
 
-		registerStubID, err = addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err = addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		time.Sleep(6 * time.Second)
 
@@ -114,7 +114,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Next step exits - stop after next step and re-register", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, models.StepsPostStepActionExit)
 		Expect(err).NotTo(HaveOccurred())
@@ -131,7 +131,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Next step exits - don't stop and keep polling for next step", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, models.StepsPostStepActionContinue)
 		Expect(err).NotTo(HaveOccurred())
@@ -159,7 +159,7 @@ var _ = Describe("Agent tests", func() {
 
 		AfterEach(func() {
 			hostID := nextHostID()
-			registerStubID, err := addRegisterStub(hostID, status, ClusterID)
+			registerStubID, err := addRegisterStub(hostID, status, InfraEnvID)
 			Expect(err).NotTo(HaveOccurred())
 
 			nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "")
@@ -185,7 +185,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("register not found - agent should stop trying to register", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStub(hostID, http.StatusNotFound, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusNotFound, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "")
@@ -210,7 +210,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Verify nextInstructionSeconds", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -224,7 +224,7 @@ var _ = Describe("Agent tests", func() {
 
 		By("verify changing nextInstructionSeconds to large number")
 		hostID = nextHostID()
-		registerStubID, err = addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err = addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err = addNextStepStub(hostID, 100, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -258,7 +258,7 @@ var _ = Describe("Agent tests", func() {
 		time.Sleep(1 * time.Second)
 		verifyRegisterRequest()
 		verifyGetNextRequest(hostID, false)
-		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		time.Sleep(time.Second * 6)
 		verifyRegisterRequest()
@@ -270,7 +270,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Step not exists", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		stepID := "wrong-step"
 		stepType := models.StepType("Step-not-exists")
@@ -300,7 +300,7 @@ var _ = Describe("Agent tests", func() {
 
 	It("Execute echo", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		stepID := "execute-step"
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "", &models.Step{
@@ -336,7 +336,7 @@ var _ = Describe("Agent tests", func() {
 	})
 	It("Multiple steps", func() {
 		hostID := nextHostID()
-		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
 		nextStepsStubID, err := addNextStepStub(hostID, defaultnextInstructionSeconds, "",
 			&models.Step{

--- a/subsystem/apivip_check_test.go
+++ b/subsystem/apivip_check_test.go
@@ -36,7 +36,7 @@ var _ = Describe("API VIP connectivity check tests", func() {
 })
 
 func setWorkerIgnitionStub(hostID string, request *models.APIVipConnectivityRequest) {
-	_, err := addRegisterStub(hostID, http.StatusCreated, ClusterID)
+	_, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 	Expect(err).NotTo(HaveOccurred())
 
 	_, err = addWorkerIgnitionStub()

--- a/subsystem/container_image_availability_test.go
+++ b/subsystem/container_image_availability_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Image availability tests", func() {
 })
 
 func startImageAvailability(hostId string, request models.ContainerImageAvailabilityRequest) {
-	_, err := addRegisterStub(hostId, http.StatusCreated, ClusterID)
+	_, err := addRegisterStub(hostId, http.StatusCreated, InfraEnvID)
 	Expect(err).ShouldNot(HaveOccurred())
 	setImageAvailabilityStub(hostId, request)
 	setReplyStartAgent(hostId)

--- a/subsystem/docker-compose.yml
+++ b/subsystem/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         "/usr/bin/agent",
         "--url",
         "http://wiremock:${WIREMOCK_PORT}",
-        "--cluster-id",
+        "--infra-env-id",
         "11111111-1111-1111-1111-111111111111",
         "--interval",
         "5",

--- a/subsystem/ntp_test.go
+++ b/subsystem/ntp_test.go
@@ -92,7 +92,7 @@ func printNtpSources(ntpResponse *models.NtpSynchronizationResponse) {
 
 func startNTPSynchronizer(hostId string, request models.NtpSynchronizationRequest) {
 	addChronyDaemonStub(hostId)
-	_, _ = addRegisterStub(hostId, http.StatusCreated, ClusterID)
+	_, _ = addRegisterStub(hostId, http.StatusCreated, InfraEnvID)
 	setReplyStartAgent(hostId)
 	waitforChronyDaemonToStart(hostId)
 

--- a/subsystem/utils.go
+++ b/subsystem/utils.go
@@ -30,7 +30,7 @@ var (
 const (
 	maxTimeout       = 300 * time.Second
 	agentServiceName = "agent"
-	clusterID        = "11111111-1111-1111-1111-111111111111" // This is redeclared here (with lowercase) to solve a lint error
+	infraEnvID        = "11111111-1111-1111-1111-111111111111" // This is redeclared here (with lowercase) to solve a lint error
 )
 
 type RequestDefinition struct {
@@ -153,15 +153,15 @@ func getSpecificStep(hostID string, verifier StepVerifier) *models.StepReply {
 }
 
 func getRegisterURL() string {
-	return fmt.Sprintf("/api/assisted-install/v1/clusters/%s/hosts", clusterID)
+	return fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/hosts", infraEnvID)
 }
 
 func getNextStepsURL(hostID string) string {
-	return fmt.Sprintf("/api/assisted-install/v1/clusters/%s/hosts/%s/instructions", clusterID, hostID)
+	return fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/hosts/%s/instructions", infraEnvID, hostID)
 }
 
 func getStepReplyURL(hostID string) string {
-	return fmt.Sprintf("/api/assisted-install/v1/clusters/%s/hosts/%s/instructions", clusterID, hostID)
+	return fmt.Sprintf("/api/assisted-install/v2/infra-envs/%s/hosts/%s/instructions", infraEnvID, hostID)
 }
 
 func addStub(stub *StubDefinition) (string, error) {
@@ -188,7 +188,7 @@ func addStub(stub *StubDefinition) (string, error) {
 	return ret.ID, nil
 }
 
-func addRegisterStubInvalidCommand(hostID string, reply int, clusterID string, retryDelay int64) (string, error) {
+func addRegisterStubInvalidCommand(hostID string, reply int, infraEnvID string, retryDelay int64) (string, error) {
 
 	hostUUID := strfmt.UUID(hostID)
 	hostKind := "host"
@@ -230,7 +230,7 @@ func addRegisterStubInvalidCommand(hostID string, reply int, clusterID string, r
 	return addStub(&stub)
 }
 
-func addRegisterStub(hostID string, reply int, clusterID string) (string, error) {
+func addRegisterStub(hostID string, reply int, infraEnvID string) (string, error) {
 	var b []byte
 	var err error
 	hostUUID := strfmt.UUID(hostID)
@@ -247,7 +247,7 @@ func addRegisterStub(hostID string, reply int, clusterID string) (string, error)
 			Command: "/usr/bin/next_step_runner",
 			Args: []string{
 				"--url", AssistedServiceURLFromAgent,
-				"--cluster-id", clusterID,
+				"--infra-env-id", infraEnvID,
 				"--host-id", hostID,
 			},
 		}
@@ -494,6 +494,12 @@ func setReplyStartAgent(hostID string) {
 	Expect(startAgent()).NotTo(HaveOccurred())
 	time.Sleep(5 * time.Second)
 	verifyRegisterRequest()
+	verifyGetNextRequest(hostID, true)
+}
+
+func setPostReply(hostID string) {
+	_, err := addStepReplyStub(hostID)
+	Expect(err).NotTo(HaveOccurred())
 	verifyGetNextRequest(hostID, true)
 }
 


### PR DESCRIPTION
Support both APIs.  The distiction is by the flags --cluster-id and --infra-env-id.
If --cluster-id is present then we use v1 APIs.  If --infra-env-id is present then we use
v2 APIs.

/cc @yevgeny-shnaidman 