### PR TITLE
Bug 1994060: Change IP version to golang's unix constant

### DIFF
--- a/src/inventory/routes_test.go
+++ b/src/inventory/routes_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/assisted-installer-agent/src/util"
 	"github.com/openshift/assisted-service/models"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 type netPair struct {
@@ -34,13 +35,6 @@ var (
 		routes: []netlink.Route{
 			{MultiPath: []*netlink.NexthopInfo{{LinkIndex: 0, Gw: net.IPv4(10, 254, 0, 1), Hops: 1},
 				{LinkIndex: 1, Gw: net.IPv4(10, 10, 1, 1), Hops: 2}}}},
-		linkNames: []string{"eth3", "virbr0"},
-	}
-
-	ipv4WithWrongFamily = netPair{
-		routes: []netlink.Route{
-			{LinkIndex: 0, Dst: nil, Gw: net.IPv4(10, 254, 0, 1)},
-			{MultiPath: []*netlink.NexthopInfo{{LinkIndex: 0, Gw: net.ParseIP("2001:1::1"), Hops: 1}}}},
 		linkNames: []string{"eth3", "virbr0"},
 	}
 
@@ -71,25 +65,25 @@ var (
 	}
 
 	ipv4Route = []*models.Route{
-		{Interface: "eth3", Gateway: "10.254.0.1", Destination: "0.0.0.0", Family: int32(familyIPv4)},
-		{Interface: "virbr0", Gateway: net.IPv4zero.String(), Destination: "192.168.122.0", Family: int32(familyIPv4)}}
+		{Interface: "eth3", Gateway: "10.254.0.1", Destination: "0.0.0.0", Family: int32(unix.AF_INET)},
+		{Interface: "virbr0", Gateway: net.IPv4zero.String(), Destination: "192.168.122.0", Family: int32(unix.AF_INET)}}
 	ipv4RouteNoInternetConnection = []*models.Route{
-		{Destination: "10.254.0.0", Gateway: net.IPv4zero.String(), Interface: "docker0", Family: int32(familyIPv4)},
-		{Destination: "172.17.0.0", Gateway: net.IPv4zero.String(), Interface: "virbr0", Family: int32(familyIPv4)},
+		{Destination: "10.254.0.0", Gateway: net.IPv4zero.String(), Interface: "docker0", Family: int32(unix.AF_INET)},
+		{Destination: "172.17.0.0", Gateway: net.IPv4zero.String(), Interface: "virbr0", Family: int32(unix.AF_INET)},
 	}
 
 	ipv4RoutWithMultiPath = []*models.Route{
-		{Interface: "eth3", Gateway: "10.254.0.1", Destination: "0.0.0.0", Family: int32(familyIPv4)}}
+		{Interface: "eth3", Gateway: "10.254.0.1", Destination: "0.0.0.0", Family: int32(unix.AF_INET)}}
 
 	ipv6Route = []*models.Route{
-		{Interface: "eth3", Gateway: "2001:1::1", Destination: net.IPv6zero.String(), Family: int32(familyIPv6)},
-		{Interface: "eth3", Gateway: net.IPv6zero.String(), Destination: "2001:2::1", Family: int32(familyIPv6)},
-		{Interface: "lo", Gateway: net.IPv6zero.String(), Destination: net.IPv6zero.String(), Family: int32(familyIPv6)}}
+		{Interface: "eth3", Gateway: "2001:1::1", Destination: net.IPv6zero.String(), Family: int32(unix.AF_INET6)},
+		{Interface: "eth3", Gateway: net.IPv6zero.String(), Destination: "2001:2::1", Family: int32(unix.AF_INET6)},
+		{Interface: "lo", Gateway: net.IPv6zero.String(), Destination: net.IPv6zero.String(), Family: int32(unix.AF_INET6)}}
 	ipv6RouteNoInternetConnection = []*models.Route{
-		{Destination: "fd2e:6f44:5dd8:5::9b87", Gateway: net.IPv6zero.String(), Interface: "docker0", Family: int32(familyIPv6)},
-		{Destination: "fe80::5054:ff:fedd:a823", Gateway: net.IPv6zero.String(), Interface: "virbr0", Family: int32(familyIPv6)},
+		{Destination: "fd2e:6f44:5dd8:5::9b87", Gateway: net.IPv6zero.String(), Interface: "docker0", Family: int32(unix.AF_INET6)},
+		{Destination: "fe80::5054:ff:fedd:a823", Gateway: net.IPv6zero.String(), Interface: "virbr0", Family: int32(unix.AF_INET6)},
 	}
-	ipv6RouteGWNil = []*models.Route{{Interface: "eth3", Gateway: "", Destination: net.IPv6zero.String(), Family: int32(familyIPv6)}}
+	ipv6RouteGWNil = []*models.Route{{Interface: "eth3", Gateway: "", Destination: net.IPv6zero.String(), Family: int32(unix.AF_INET6)}}
 )
 
 type testHandler struct {
@@ -134,13 +128,12 @@ var _ = Describe("Route test", func() {
 			expected   []*models.Route
 			errStrFrag string
 		}{
-			{"should find all the routes when the default route is first", testHandler{routes: ipV4GW.routes, linkNames: ipV4GW.linkNames, family: familyIPv4}, len(ipV4GW.routes), ipv4Route, ""},
-			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv4}, len(nothing.routes), []*models.Route{}, ""},
-			{"should have routes when no internet connection/default route", testHandler{routes: ipv4NoInternetConnection.routes, linkNames: ipv4NoInternetConnection.linkNames, family: familyIPv4}, len(ipv4NoInternetConnection.routes), ipv4RouteNoInternetConnection, ""},
-			{"should return error when retrieving routes", testHandler{errorRoutes: fmt.Errorf("cannot retrieve routes"), family: familyIPv4}, 0, nil, "cannot retrieve routes"},
-			{"should return error when retrieving link name", testHandler{routes: ipV4GW.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: familyIPv4}, 0, nil, "cannot retrieve link name"},
-			{"should parse from multipath", testHandler{routes: ipv4WithMultiPath.routes, linkNames: ipv4WithMultiPath.linkNames, family: familyIPv4}, len(ipv4WithMultiPath.routes), ipv4RoutWithMultiPath, ""},
-			{"should filter when route contains the wrong family", testHandler{routes: ipv4WithWrongFamily.routes, linkNames: ipv4WithWrongFamily.linkNames, family: familyIPv4}, 1, ipv4Route, ""},
+			{"should find all the routes when the default route is first", testHandler{routes: ipV4GW.routes, linkNames: ipV4GW.linkNames, family: unix.AF_INET}, len(ipV4GW.routes), ipv4Route, ""},
+			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: unix.AF_INET}, len(nothing.routes), []*models.Route{}, ""},
+			{"should have routes when no internet connection/default route", testHandler{routes: ipv4NoInternetConnection.routes, linkNames: ipv4NoInternetConnection.linkNames, family: unix.AF_INET}, len(ipv4NoInternetConnection.routes), ipv4RouteNoInternetConnection, ""},
+			{"should return error when retrieving routes", testHandler{errorRoutes: fmt.Errorf("cannot retrieve routes"), family: unix.AF_INET}, 0, nil, "cannot retrieve routes"},
+			{"should return error when retrieving link name", testHandler{routes: ipV4GW.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: unix.AF_INET}, 0, nil, "cannot retrieve link name"},
+			{"should parse from multipath", testHandler{routes: ipv4WithMultiPath.routes, linkNames: ipv4WithMultiPath.linkNames, family: unix.AF_INET}, len(ipv4WithMultiPath.routes), ipv4RoutWithMultiPath, ""},
 		}
 
 		for _, tc := range testCases {
@@ -166,12 +159,12 @@ var _ = Describe("Route test", func() {
 			expected   []*models.Route
 			errStrFrag string
 		}{
-			{"should find all the routes when the default route is first", testHandler{routes: ipV6GW.routes, linkNames: ipV6GW.linkNames, family: familyIPv6}, len(ipV6GW.routes), ipv6Route, ""},
-			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: familyIPv6}, len(nothing.routes), nil, ""},
-			{"should have routes when no internet connection/default route", testHandler{routes: ipv6NoInternetConnection.routes, linkNames: ipv6NoInternetConnection.linkNames, family: familyIPv6}, len(ipv6NoInternetConnection.routes), ipv6RouteNoInternetConnection, ""},
-			{"should return error when retrieving routes", testHandler{errorRoutes: fmt.Errorf("cannot retrieve routes"), family: familyIPv6}, 0, nil, "cannot retrieve routes"},
-			{"should return error when retrieving link name", testHandler{routes: ipV6GW.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: familyIPv6}, 0, nil, "cannot retrieve link name"},
-			{"should have a route when gateway is nil", testHandler{routes: ipV6GWNil.routes, linkNames: ipV6GWNil.linkNames, family: familyIPv6}, len(ipV6GWNil.routes), ipv6RouteGWNil, ""},
+			{"should find all the routes when the default route is first", testHandler{routes: ipV6GW.routes, linkNames: ipV6GW.linkNames, family: unix.AF_INET6}, len(ipV6GW.routes), ipv6Route, ""},
+			{"should have no routes", testHandler{routes: nothing.routes, linkNames: nothing.linkNames, family: unix.AF_INET6}, len(nothing.routes), nil, ""},
+			{"should have routes when no internet connection/default route", testHandler{routes: ipv6NoInternetConnection.routes, linkNames: ipv6NoInternetConnection.linkNames, family: unix.AF_INET6}, len(ipv6NoInternetConnection.routes), ipv6RouteNoInternetConnection, ""},
+			{"should return error when retrieving routes", testHandler{errorRoutes: fmt.Errorf("cannot retrieve routes"), family: unix.AF_INET6}, 0, nil, "cannot retrieve routes"},
+			{"should return error when retrieving link name", testHandler{routes: ipV6GW.routes, errorLinkName: fmt.Errorf("cannot retrieve link name"), family: unix.AF_INET6}, 0, nil, "cannot retrieve link name"},
+			{"should have a route when gateway is nil", testHandler{routes: ipV6GWNil.routes, linkNames: ipV6GWNil.linkNames, family: unix.AF_INET6}, len(ipV6GWNil.routes), ipv6RouteGWNil, ""},
 		}
 		for _, tc := range testCases {
 			tc := tc


### PR DESCRIPTION
Aligns the IP protocol version used to retrieve the routes with the one used in the netlink library:
* IPv4 : unix.AF_INET
* IPv6: unix.AF_INET6

This change also fixes a side effect that was caused by using the wrong IP protocol version when calling netlink's API to retrieve all the routes (`netlink.RouteList(link,IPversion)`), which lead to netlink not being able to filter out the routes correctly because of a mismatched protocol version.

https://github.com/vishvananda/netlink/blob/f5de75959ad544e80f08d6adaffa7026df3380ef/nl/nl_linux.go#L22-L23
```golang
	FAMILY_V4   = unix.AF_INET
	FAMILY_V6   = unix.AF_INET6
```

Currently, querying for the IPv4 routes or IPv6 routes, the API call returns all routes for all versions in the same call.

```bash
Routes for family 4
[Family 2] route {Ifindex: 4 Dst: <nil> Src: <nil> Gw: 10.19.32.254 Flags: [] Table: 254}
[Family 2] route {Ifindex: 5 Dst: 10.19.32.128/27 Src: 10.19.32.130 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 4 Dst: 10.19.32.192/26 Src: 10.19.32.209 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 38 Dst: 10.88.0.0/16 Src: 10.88.0.1 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 6 Dst: 192.168.122.0/24 Src: 192.168.122.1 Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 1 Dst: ::1/128 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 4 Dst: 2620:52:0:1343::e8/128 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 4 Dst: 2620:52:0:1343::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 38 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 41 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 144 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 145 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 146 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 147 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 148 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 149 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 179 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 180 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 181 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 4 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 4 Dst: <nil> Src: <nil> Gw: 2620:52:0:1343::fe Flags: [] Table: 254}
Routes for family 6
[Family 2] route {Ifindex: 4 Dst: <nil> Src: <nil> Gw: 10.19.32.254 Flags: [] Table: 254}
[Family 2] route {Ifindex: 5 Dst: 10.19.32.128/27 Src: 10.19.32.130 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 4 Dst: 10.19.32.192/26 Src: 10.19.32.209 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 38 Dst: 10.88.0.0/16 Src: 10.88.0.1 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 6 Dst: 192.168.122.0/24 Src: 192.168.122.1 Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 1 Dst: ::1/128 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 4 Dst: 2620:52:0:1343::e8/128 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 4 Dst: 2620:52:0:1343::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
...
```

After applying this change, the routes are now properly filtered:

```bash
Routes for family 2
[Family 2] route {Ifindex: 4 Dst: <nil> Src: <nil> Gw: 10.19.32.254 Flags: [] Table: 254}
[Family 2] route {Ifindex: 5 Dst: 10.19.32.128/27 Src: 10.19.32.130 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 4 Dst: 10.19.32.192/26 Src: 10.19.32.209 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 38 Dst: 10.88.0.0/16 Src: 10.88.0.1 Gw: <nil> Flags: [] Table: 254}
[Family 2] route {Ifindex: 6 Dst: 192.168.122.0/24 Src: 192.168.122.1 Gw: <nil> Flags: [] Table: 254}
Routes for family 10
[Family 10] route {Ifindex: 1 Dst: ::1/128 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 4 Dst: 2620:52:0:1343::e8/128 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 4 Dst: 2620:52:0:1343::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 38 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 41 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 144 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 145 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 146 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 147 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
[Family 10] route {Ifindex: 148 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
...
``` 

Note that IPv4 is family 2 (0x2) and IPv6 is family 10 (0xa) in hexadecimal, as described in the golang source code:
https://cs.opensource.google/go/x/sys/+/master:unix/zerrors_linux.go;l=31-32

/assign @ori-amizur 