### PR TITLE
OCPRHV-591: Add oVirt support to the agent side

### DIFF
--- a/src/inventory/system_vendor.go
+++ b/src/inventory/system_vendor.go
@@ -17,6 +17,7 @@ func isVirtual(product string) bool {
 		"Virtual Machine",
 		"AHV",
 		"HVM domU",
+		"oVirt",
 	} {
 		if strings.Contains(product, vmTech) {
 			return true
@@ -24,6 +25,12 @@ func isVirtual(product string) bool {
 	}
 
 	return false
+}
+
+// For oVirt VMs the correct platform can be detected only by the Family value,
+// this function is used to check that and update the productName accordingly.
+func isOVirtPlatform(family string) bool {
+	return family == "oVirt" || family == "RHV"
 }
 
 func GetVendor(dependencies util.IDependencies) *models.SystemVendor {
@@ -39,7 +46,10 @@ func GetVendor(dependencies util.IDependencies) *models.SystemVendor {
 	ret.SerialNumber = product.SerialNumber
 	ret.ProductName = product.Name
 	ret.Manufacturer = product.Vendor
-	ret.Virtual = isVirtual(product.Name)
+	if isOVirtPlatform(product.Family){
+		ret.ProductName = "oVirt"
+	}
+	ret.Virtual = isVirtual(ret.ProductName)
 
 	return &ret
 }

--- a/src/inventory/system_vendor_test.go
+++ b/src/inventory/system_vendor_test.go
@@ -52,8 +52,20 @@ var _ = Describe("System vendor test", func() {
 			{"AHV", true},
 			{"HVM domU", true},
 			{"20T1S39D3N (LENOVO_MT_20T1_BU_Think_FM_ThinkPad T14s Gen 1)", false},
+			{"oVirt", true},
 		} {
 			Expect(isVirtual(test.Product)).Should(Equal(test.IsVm))
 		}
+	})
+	It("oVirt product detection", func() {
+		dependencies.On("Product", ghw.WithChroot("/host")).Return(&ghw.ProductInfo{
+			Family:      "oVirt",
+		}, nil).Once()
+
+		ret := GetVendor(dependencies)
+		Expect(ret).To(Equal(&models.SystemVendor{
+			ProductName: "oVirt",
+			Virtual:     true,
+		}))
 	})
 })


### PR DESCRIPTION
To add oVirt provider support some modifications need to be done on the agent side.
oVirt platform is detected according to the family parameter and not by product name 
which can be various, to detect the right platform and add it to the isVitual list a new 
function was added and it will change the host product type to match oVirt one, it will
ensure that the rest of the flow will remain the same as for the different types of hosts.