### PR TITLE
MGMT-7457: Adding TPM version to host inventory.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jaypipes/pcidb v0.6.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
-	github.com/openshift/assisted-service v1.0.10-0.20210825150850-56247fd7d2d9
+	github.com/openshift/assisted-service v1.0.10-0.20210913205447-a96c596238d8
 	github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,7 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/brancz/gojsontoyaml v0.0.0-20190425155809-e8bd32d46b3d/go.mod h1:IyUJYN1gvWjtLF5ZuygmxbnsAyP3aJS6cHzIuZY50B0=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
@@ -983,6 +984,10 @@ github.com/openshift/assisted-service v1.0.10-0.20210817100849-4962ca422755 h1:K
 github.com/openshift/assisted-service v1.0.10-0.20210817100849-4962ca422755/go.mod h1:gZbvXtrg4RY2IODd/ItQbz/f44FyujyduP/a8uJ0mUU=
 github.com/openshift/assisted-service v1.0.10-0.20210825150850-56247fd7d2d9 h1:pjHdJrC2sTcpQv7JsfH/VP0KhuebhpPcekbbSQK9GxA=
 github.com/openshift/assisted-service v1.0.10-0.20210825150850-56247fd7d2d9/go.mod h1:gZbvXtrg4RY2IODd/ItQbz/f44FyujyduP/a8uJ0mUU=
+github.com/openshift/assisted-service v1.0.10-0.20210905195728-76425eb6a476 h1:goj8GFtQ1wDxZaDHhNts6rw/loA5fPPh7FFTKxh2t8M=
+github.com/openshift/assisted-service v1.0.10-0.20210905195728-76425eb6a476/go.mod h1:gZbvXtrg4RY2IODd/ItQbz/f44FyujyduP/a8uJ0mUU=
+github.com/openshift/assisted-service v1.0.10-0.20210913205447-a96c596238d8 h1:Ir+PwKvBWmFGB6XJCeD+1uK4syx0o8YBD18GB2QQEyo=
+github.com/openshift/assisted-service v1.0.10-0.20210913205447-a96c596238d8/go.mod h1:SsuNh9LQjVGO4N8PG5fp8G0LVSkVcWcF158yOCJFAj8=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd h1:5JV3JearFzKVj+bmc0PPrb1+bbgSye6loMQihlc3JBY=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd/go.mod h1:+duukQisb5LU1bMtLalsHZc1wM69D5sH3TuiyvAQhhA=

--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -23,6 +23,7 @@ func ReadInventory() *models.Inventory {
 		SystemVendor: GetVendor(d),
 		Timestamp:    time.Now().Unix(),
 		Routes:       GetRoutes(d),
+		TpmVersion:   GetTPM(d),
 	}
 	return &ret
 }

--- a/src/inventory/tpm.go
+++ b/src/inventory/tpm.go
@@ -1,0 +1,30 @@
+package inventory
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/openshift/assisted-installer-agent/src/util"
+	"github.com/sirupsen/logrus"
+)
+
+func GetTPM(dependencies util.IDependencies) string {
+
+	stdOut, stdErr, exitCode := dependencies.Execute("cat", "/sys/class/tpm/tpm0/tpm_version_major")
+	if exitCode != 0 {
+		if strings.Contains(stdErr, "No such file or directory") {
+			return "none"
+		}
+		logrus.WithError(errors.New(stdErr)).Warn("Error checking TPM version")
+		return ""
+	}
+
+	switch stdOut {
+	case "1":
+		return "1.2"
+	case "2":
+		return "2.0"
+	}
+
+	return stdOut
+}

--- a/src/inventory/tpm_test.go
+++ b/src/inventory/tpm_test.go
@@ -1,0 +1,48 @@
+package inventory
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/util"
+)
+
+var _ = Describe("TPM test", func() {
+
+	var dependencies *util.MockIDependencies
+
+	BeforeEach(func() {
+		dependencies = newDependenciesMock()
+	})
+
+	AfterEach(func() {
+		dependencies.AssertExpectations(GinkgoT())
+	})
+
+	It("TPM disabled in BIOS", func() {
+
+		dependencies.On("Execute", "cat", "/sys/class/tpm/tpm0/tpm_version_major").Return("", "cat: /sys/class/tpm/tpm0/tpm_version_major: No such file or directory", 1).Once()
+		ret := GetTPM(dependencies)
+		Expect(ret).To(Equal("none"))
+	})
+
+	It("Execute error", func() {
+
+		dependencies.On("Execute", "cat", "/sys/class/tpm/tpm0/tpm_version_major").Return("", "Any other error", 1).Once()
+		ret := GetTPM(dependencies)
+		Expect(ret).To(Equal(""))
+	})
+
+	It("Unsupported TPM version", func() {
+
+		dependencies.On("Execute", "cat", "/sys/class/tpm/tpm0/tpm_version_major").Return("1", "", 0).Once()
+		ret := GetTPM(dependencies)
+		Expect(ret).To(Equal("1.2"))
+	})
+
+	It("Happy flow", func() {
+
+		dependencies.On("Execute", "cat", "/sys/class/tpm/tpm0/tpm_version_major").Return("2", "", 0).Once()
+		ret := GetTPM(dependencies)
+		Expect(ret).To(Equal("2.0"))
+	})
+})


### PR DESCRIPTION
The TPM version is validated in the service to make sure the specific
TPM HW is supported by openshift.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>