### PR TITLE
 MGMT-7847: Don't check verify CIDR in the host

### DIFF
--- a/src/apivip_check/apivip_check_test.go
+++ b/src/apivip_check/apivip_check_test.go
@@ -32,19 +32,19 @@ var _ = Describe("API connectivity check test", func() {
 	Context("Ignition file", func() {
 		It("Download ignition file successfully", func() {
 			srv = serverMock(ignitionMock)
-			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false), log)
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
 			Expect(exitCode).Should(Equal(0))
 		})
 
 		It("Invalid ignition file format", func() {
 			srv = serverMock(ignitionMockInvalid)
-			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false), log)
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
 			Expect(exitCode).Should(Equal(0))
 		})
 
 		It("Empty ignition", func() {
 			srv = serverMock(ignitionMockEmpty)
-			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false), log)
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
 			Expect(exitCode).Should(Equal(0))
 		})
 	})
@@ -52,45 +52,20 @@ var _ = Describe("API connectivity check test", func() {
 	Context("API URL", func() {
 		It("Invalid API URL", func() {
 			url := "http://127.0.0.1:2345"
-			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&url, false), log)
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(&url), log)
 			Expect(exitCode).Should(Equal(0))
 		})
 
 		It("Missing API URL", func() {
-			_, _, exitCode := CheckAPIConnectivity(getRequestStr(nil, false), log)
+			_, _, exitCode := CheckAPIConnectivity(getRequestStr(nil), log)
 			Expect(exitCode).Should(Equal(-1))
-		})
-	})
-
-	Context("Verify CIDR", func() {
-		It("Verification success - hostname", func() {
-			srv = serverMock(ignitionMock)
-			err := verifyCIDR("http://localhost:1234", log)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("Verification success - IP address", func() {
-			srv = serverMock(ignitionMock)
-			err := verifyCIDR("http://127.0.0.1:1234", log)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("Invalid URL", func() {
-			err := verifyCIDR("http://invalid:1234", log)
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("CIDR not suitable", func() {
-			err := verifyCIDR("http://example.com:1234", log)
-			Expect(err).To(HaveOccurred())
 		})
 	})
 })
 
-func getRequestStr(url *string, verifyCidr bool) string {
+func getRequestStr(url *string) string {
 	request := models.APIVipConnectivityRequest{
-		URL:        url,
-		VerifyCidr: verifyCidr,
+		URL: url,
 	}
 
 	requestBytes, err := json.Marshal(request)


### PR DESCRIPTION
The CIDR validation, the majorityGroup check, and the L2 and L3 validations, are
already performed by assisted service when validating the cluster, host, and network
data. There should not be a need to replicate this validation in the agent itself.

UPDATE
==

This was manually tested by deploying a 3-masters spoke cluster and then a 1 worker (on a separate network). Tests were done by myself and @alknopfler 

![image (11)](https://user-images.githubusercontent.com/13816/134003438-bd56750a-e221-4d4c-8b4f-8a393f5d2064.png)


Signed-off-by: Flavio Percoco <flavio@redhat.com>