### PR TITLE
MGMT-7761: Switch to stream8

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -11,7 +11,8 @@ COPY . .
 
 RUN make build
 
-FROM quay.io/centos/centos:centos8
+FROM quay.io/centos/centos:stream8
+
 RUN dnf install -y \
 		findutils iputils \
 		podman \


### PR DESCRIPTION
The original plan was to move all images to ubi8. This is not possible due to the lack
of some packages that are needed for other projects. We are now going to switch all images
to stream8 with the hope that the consistency accross repos will prevent (or help) with
debugging current/future issues in CI.

The goal is to keep component's builds as consistent as possible in the channels we are
releasing them on

Signed-off-by: Flavio Percoco <flavio@redhat.com>