### PR TITLE
NO-ISSUE: Removing \n suffix from TPM version.

### DIFF
--- a/src/inventory/tpm.go
+++ b/src/inventory/tpm.go
@@ -18,6 +18,7 @@ func GetTPM(dependencies util.IDependencies) string {
 		logrus.WithError(errors.New(stdErr)).Warn("Error checking TPM version")
 		return ""
 	}
+	stdOut = strings.TrimSuffix(stdOut, "\n")
 
 	switch stdOut {
 	case "1":


### PR DESCRIPTION
It will make the agent send an invalid TPM version format to the service
and, therefore, to fail.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>