### PR TITLE
#249 Support using inventory outside a container

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -980,14 +980,6 @@ github.com/openshift/api v0.0.0-20200901182017-7ac89ba6b971/go.mod h1:M3xexPhgM8
 github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267/go.mod h1:RDvBcRQMGLa3aNuDuejVBbTEQj/2i14NXdpOLqbNBvM=
 github.com/openshift/api v0.0.0-20210216211028-bb81baaf35cd/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
-github.com/openshift/assisted-service v1.0.10-0.20210817100849-4962ca422755 h1:KZiQMhICziFgOWXRwDkLt/qrxhQ1ioSUOB4IiMfluQg=
-github.com/openshift/assisted-service v1.0.10-0.20210817100849-4962ca422755/go.mod h1:gZbvXtrg4RY2IODd/ItQbz/f44FyujyduP/a8uJ0mUU=
-github.com/openshift/assisted-service v1.0.10-0.20210825150850-56247fd7d2d9 h1:pjHdJrC2sTcpQv7JsfH/VP0KhuebhpPcekbbSQK9GxA=
-github.com/openshift/assisted-service v1.0.10-0.20210825150850-56247fd7d2d9/go.mod h1:gZbvXtrg4RY2IODd/ItQbz/f44FyujyduP/a8uJ0mUU=
-github.com/openshift/assisted-service v1.0.10-0.20210905195728-76425eb6a476 h1:goj8GFtQ1wDxZaDHhNts6rw/loA5fPPh7FFTKxh2t8M=
-github.com/openshift/assisted-service v1.0.10-0.20210905195728-76425eb6a476/go.mod h1:gZbvXtrg4RY2IODd/ItQbz/f44FyujyduP/a8uJ0mUU=
-github.com/openshift/assisted-service v1.0.10-0.20210913205447-a96c596238d8 h1:Ir+PwKvBWmFGB6XJCeD+1uK4syx0o8YBD18GB2QQEyo=
-github.com/openshift/assisted-service v1.0.10-0.20210913205447-a96c596238d8/go.mod h1:SsuNh9LQjVGO4N8PG5fp8G0LVSkVcWcF158yOCJFAj8=
 github.com/openshift/assisted-service v1.0.10-0.20210929010224-72700cdbd088 h1:76NH3Tcd9woHBe2LJ3bRp+I4kaD/WPL40MYz7nLHZwQ=
 github.com/openshift/assisted-service v1.0.10-0.20210929010224-72700cdbd088/go.mod h1:SsuNh9LQjVGO4N8PG5fp8G0LVSkVcWcF158yOCJFAj8=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=

--- a/src/commands/connectivity_check.go
+++ b/src/commands/connectivity_check.go
@@ -19,7 +19,7 @@ import (
 
 func getOutgoingNics() []string {
 	ret := make([]string, 0)
-	d := util.NewDependencies()
+	d := util.NewDependencies("")
 	interfaces, err := d.Interfaces()
 	if err != nil {
 		log.WithError(err).Warnf("Get outgoing nics")

--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -170,7 +170,9 @@ func checkEligibility(disk *ghw.Disk) (notEligibleReasons []string, isInstallati
 
 func (d *disks) getDisks() []*models.Disk {
 	ret := make([]*models.Disk, 0)
-	blockInfo, err := d.dependencies.Block(ghw.WithChroot("/host"))
+	var blockInfo *ghw.BlockInfo
+	var err error
+	blockInfo, err = d.dependencies.Block(ghw.WithChroot(d.dependencies.GetGhwChrootRoot()))
 	if err != nil {
 		logrus.WithError(err).Warnf("While getting disks info")
 		return ret

--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/assisted-service/models"
 )
 
-func ReadInventory() *models.Inventory {
-	d := util.NewDependencies()
+func ReadInventory(c *Options) *models.Inventory {
+	d := util.NewDependencies(c.GhwChrootRoot)
 	ret := models.Inventory{
 		BmcAddress:   GetBmcAddress(d),
 		BmcV6address: GetBmcV6Address(d),
@@ -29,7 +29,11 @@ func ReadInventory() *models.Inventory {
 }
 
 func CreateInventoryInfo() []byte {
-	in := ReadInventory()
+	in := ReadInventory(&Options{GhwChrootRoot: "/host"})
 	b, _ := json.Marshal(&in)
 	return b
+}
+
+type Options struct {
+	GhwChrootRoot string
 }

--- a/src/inventory/main_test.go
+++ b/src/inventory/main_test.go
@@ -9,7 +9,13 @@ import (
 )
 
 func newDependenciesMock() *util.MockIDependencies {
-	return &util.MockIDependencies{}
+	d := &util.MockIDependencies{}
+	mockGetGhwChrootRoot(d)
+	return d
+}
+
+func mockGetGhwChrootRoot(dependencies *util.MockIDependencies) {
+	dependencies.On("GetGhwChrootRoot").Return("/host").Maybe()
 }
 
 func TestSubsystem(t *testing.T) {

--- a/src/inventory/system_vendor.go
+++ b/src/inventory/system_vendor.go
@@ -35,8 +35,9 @@ func isOVirtPlatform(family string) bool {
 
 func GetVendor(dependencies util.IDependencies) *models.SystemVendor {
 	var ret models.SystemVendor
-
-	product, err := dependencies.Product(ghw.WithChroot("/host"))
+	var product *ghw.ProductInfo
+	var err error
+	product, err = dependencies.Product(ghw.WithChroot(dependencies.GetGhwChrootRoot()))
 
 	if err != nil {
 		logrus.Errorf("Error running ghw.Product with /host chroot:: %s", err)

--- a/src/inventory/system_vendor_test.go
+++ b/src/inventory/system_vendor_test.go
@@ -59,7 +59,7 @@ var _ = Describe("System vendor test", func() {
 	})
 	It("oVirt product detection", func() {
 		dependencies.On("Product", ghw.WithChroot("/host")).Return(&ghw.ProductInfo{
-			Family:      "oVirt",
+			Family: "oVirt",
 		}, nil).Once()
 
 		ret := GetVendor(dependencies)

--- a/src/logs_sender/mock_LogsSender.go
+++ b/src/logs_sender/mock_LogsSender.go
@@ -168,13 +168,13 @@ func (_m *MockLogsSender) GatherInstallerLogs(targetDir string) error {
 	return r0
 }
 
-// LogProgressReport provides a mock function with given fields: clusterID, hostID, inventoryUrl, pullSecretToken, progress
-func (_m *MockLogsSender) LogProgressReport(clusterID strfmt.UUID, hostID strfmt.UUID, inventoryUrl string, pullSecretToken string, progress models.LogsState) error {
-	ret := _m.Called(clusterID, hostID, inventoryUrl, pullSecretToken, progress)
+// LogProgressReport provides a mock function with given fields: infraEnvID, hostID, inventoryUrl, pullSecretToken, progress
+func (_m *MockLogsSender) LogProgressReport(infraEnvID strfmt.UUID, hostID strfmt.UUID, inventoryUrl string, pullSecretToken string, progress models.LogsState) error {
+	ret := _m.Called(infraEnvID, hostID, inventoryUrl, pullSecretToken, progress)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(strfmt.UUID, strfmt.UUID, string, string, models.LogsState) error); ok {
-		r0 = rf(clusterID, hostID, inventoryUrl, pullSecretToken, progress)
+		r0 = rf(infraEnvID, hostID, inventoryUrl, pullSecretToken, progress)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/src/util/dependencies.go
+++ b/src/util/dependencies.go
@@ -26,10 +26,16 @@ type IDependencies interface {
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
 	GPU(opts ...*ghw.WithOption) (*ghw.GPUInfo, error)
 	Memory(opts ...*ghw.WithOption) (*ghw.MemoryInfo, error)
+	GetGhwChrootRoot() string
 }
 
 type Dependencies struct {
 	NetlinkRouteFinder
+	GhwChrootRoot string
+}
+
+func (d *Dependencies) GetGhwChrootRoot() string {
+	return d.GhwChrootRoot
 }
 
 func (d *Dependencies) Execute(command string, args ...string) (stdout string, stderr string, exitCode int) {
@@ -88,6 +94,8 @@ func (d *Dependencies) Memory(opts ...*ghw.WithOption) (*ghw.MemoryInfo, error) 
 	return ghw.Memory(opts...)
 }
 
-func NewDependencies() IDependencies {
-	return &Dependencies{}
+func NewDependencies(ghwChrootRoot string) IDependencies {
+	return &Dependencies{
+		GhwChrootRoot: ghwChrootRoot,
+	}
 }

--- a/src/util/mock_IDependencies.go
+++ b/src/util/mock_IDependencies.go
@@ -160,6 +160,20 @@ func (_m *MockIDependencies) GPU(opts ...*option.Option) (*gpu.Info, error) {
 	return r0, r1
 }
 
+// GetGhwChrootRoot provides a mock function with given fields:
+func (_m *MockIDependencies) GetGhwChrootRoot() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // Hostname provides a mock function with given fields:
 func (_m *MockIDependencies) Hostname() (string, error) {
 	ret := _m.Called()


### PR DESCRIPTION
k4e-device-worker uses the inventory for collecting hardware
information. However, the k4e-device-worker runs as a process on the
host and not inside a container.
Therefore the path for its filesystem doesn't need to be chrooted.

Signed-off-by: Moti Asayag <masayag@redhat.com>