### PR TITLE
Bug 2017502: don't return error from Resolver in case domain not found,return only empty list

### DIFF
--- a/src/domain_resolution/domain_resolution_test.go
+++ b/src/domain_resolution/domain_resolution_test.go
@@ -75,6 +75,14 @@ var _ = Describe("Domain resolution", func() {
 		}
 	})
 
+	Context("Resolution error", func() {
+		dm := DomainResolver{}
+		ips, err:= dm.Resolve("faillallthetimeigal-blbl.com")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ips).Should(BeEmpty())
+	})
+
+
 	Context("Run", func() {
 		It("No domains", func() {
 			// Request resolution for an empty list of domains


### PR DESCRIPTION
Bug 2017502: don't return error from Resolver in case domain not found,return only empty list