### PR TITLE
NO-ISSUE: Logs sender lsblk unknown column error fix

### DIFF
--- a/src/logs_sender/send_logs.go
+++ b/src/logs_sender/send_logs.go
@@ -200,7 +200,7 @@ func getMountLogs(l LogsSender, outputFilePath string) error {
 	}
 	defer logfile.Close()
 
-	result = util.LogPrivilegedCommandOutput(logfile, result, "List block devices", lsblk, "-o NAME,MAJ:MIN,SIZE,TYPE,FSTYPE,KNAME,MODEL,UUID,WWN,HCTL,VENDOR,STATE,TRAN,PKNAME")
+	result = util.LogPrivilegedCommandOutput(logfile, result, "List block devices", lsblk, "-o", "NAME,MAJ:MIN,SIZE,TYPE,FSTYPE,KNAME,MODEL,UUID,WWN,HCTL,VENDOR,STATE,TRAN,PKNAME")
 	result = util.LogPrivilegedCommandOutput(logfile, result, "List mounts", findmnt, "--df")
 	result = logDisksByCategory("id", logfile, result)
 	result = logDisksByCategory("path", logfile, result)


### PR DESCRIPTION
When the installer launches the logs-sender binary from the agent, we
encounter this error:

`Logs were sent\n1 error occurred:\n\t* /usr/bin/lsblk failed: 1 lsblk: unknown column:  NAME,MAJ:MIN,SIZE,TYPE,FSTYPE,KNAME,MODEL,UUID,WWN,HCTL,VENDOR,STATE,TRAN,PKNAME\n\n\n\n\n`

It is caused by the columns list and the `-o` flag being inside the same
parameter.

/cc @mkowalski

This commit separates them to avoid this error