### PR TITLE
MGMT-7941: Fix agent dry reboot condition in wrong code path

### DIFF
--- a/src/agent/main/main.go
+++ b/src/agent/main/main.go
@@ -32,17 +32,17 @@ func main() {
 				reRegistrerDelay = defaultRetryDelay
 			}
 
-			if config.GlobalDryRunConfig.DryRunEnabled {
-				// Check if the step runner died just because the installer signaled fake reboot
-				if util.DryRebootHappened() {
-					log.Infof("Dry reboot happened, exiting")
-					return
-				}
-			}
-
 			log.WithError(err).Errorf("Next step runner has crashed and will be restarted in %s", reRegistrerDelay)
 			time.Sleep(reRegistrerDelay)
 			continue
+		}
+
+		if config.GlobalDryRunConfig.DryRunEnabled {
+			// Check if the step runner died just because the installer signaled fake reboot
+			if util.DryRebootHappened() {
+				log.Infof("Dry reboot happened, exiting")
+				break
+			}
 		}
 
 		log.Info("Next step runner exited, going to re-register host")


### PR DESCRIPTION
The agent binary only checked if a reboot happened when next_step_runner has
an error. This is not the case when reboots happen, next_step_runner exits
cleanly with a 0 exit code, so we should only check dry reboot in the agent
if next_step_runner had no error