### PR TITLE
MGMT-7941: Allow forcing the IP address and hostname of the agent in dry mode

### DIFF
--- a/src/config/dry_run_config.go
+++ b/src/config/dry_run_config.go
@@ -12,7 +12,9 @@ import (
 type DryRunConfig struct {
 	DryRunEnabled        bool   `envconfig:"DRY_ENABLE"`
 	ForcedHostID         string `envconfig:"DRY_HOST_ID"`
-	ForcedMacAddress     string `envconfig:"DRY_MAC_ADDRESS"`
+	ForcedHostIPv4       string `envconfig:"DRY_FORCED_HOST_IPV4"`
+	ForcedMacAddress     string `envconfig:"DRY_FORCED_MAC_ADDRESS"`
+	ForcedHostname       string `envconfig:"DRY_FORCED_HOSTNAME"`
 	FakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH"`
 }
 
@@ -21,7 +23,9 @@ var GlobalDryRunConfig DryRunConfig
 var DefaultDryRunConfig DryRunConfig = DryRunConfig{
 	DryRunEnabled:        false,
 	ForcedHostID:         "",
+	ForcedHostIPv4:       "",
 	ForcedMacAddress:     "",
+	ForcedHostname:       "",
 	FakeRebootMarkerPath: "",
 }
 
@@ -35,6 +39,8 @@ func ProcessDryRunArgs() {
 	flag.BoolVar(&GlobalDryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
 	flag.StringVar(&GlobalDryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
 	flag.StringVar(&GlobalDryRunConfig.ForcedMacAddress, "force-mac", DefaultDryRunConfig.ForcedMacAddress, "The fake mac address to give to the first network interface")
+	flag.StringVar(&GlobalDryRunConfig.ForcedHostname, "force-hostname", DefaultDryRunConfig.ForcedHostname, "The fake hostname to give to this host")
+	flag.StringVar(&GlobalDryRunConfig.ForcedHostIPv4, "forced-ipv4", DefaultDryRunConfig.ForcedHostIPv4, "The fake ip address to give to the host's network interface")
 	flag.StringVar(&GlobalDryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
 	flag.Parse()
 }

--- a/src/inventory/dry_inventory.go
+++ b/src/inventory/dry_inventory.go
@@ -1,0 +1,35 @@
+package inventory
+
+import (
+	"fmt"
+
+	"github.com/openshift/assisted-installer-agent/src/config"
+	"github.com/openshift/assisted-service/models"
+)
+
+func applyDryRunConfig(inventory *models.Inventory) {
+	targetInterface, err := findRelevantInterface(inventory)
+	if err != nil {
+		return
+	}
+
+	// Override the mac address & IPv4 address to the user requested one
+	inventory.Interfaces[targetInterface].MacAddress = config.GlobalDryRunConfig.ForcedMacAddress
+	inventory.Interfaces[targetInterface].IPV4Addresses[0] = config.GlobalDryRunConfig.ForcedHostIPv4
+
+	// Throw away other interfaces to avoid some exotic bugs relating to duplicate mac addreses from two different hosts
+	inventory.Interfaces = []*models.Interface{inventory.Interfaces[targetInterface]}
+}
+
+// findRelevantInterface returns the index of the first interface
+// which has an ipv4 address
+func findRelevantInterface(inventory *models.Inventory) (int, error) {
+	for interfaceIndex, iface := range inventory.Interfaces {
+		if len(iface.IPV4Addresses) > 0 {
+			return interfaceIndex, nil
+		}
+	}
+
+	return -1, fmt.Errorf("No suitable interface for dry run reconfiguration found in %+v", inventory.Interfaces)
+}
+

--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -33,7 +33,7 @@ func CreateInventoryInfo() []byte {
 	in := ReadInventory(&Options{GhwChrootRoot: "/host"})
 
 	if config.GlobalDryRunConfig.DryRunEnabled {
-		in.Interfaces[0].MacAddress = config.GlobalDryRunConfig.ForcedMacAddress
+		applyDryRunConfig(in)
 	}
 
 	b, _ := json.Marshal(&in)

--- a/src/util/dependencies.go
+++ b/src/util/dependencies.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/jaypipes/ghw"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/vishvananda/netlink"
 )
 
@@ -51,6 +52,10 @@ func (d *Dependencies) Stat(fname string) (os.FileInfo, error) {
 }
 
 func (d *Dependencies) Hostname() (string, error) {
+	if config.GlobalDryRunConfig.DryRunEnabled {
+		return config.GlobalDryRunConfig.ForcedHostname, nil
+	}
+
 	return os.Hostname()
 }
 


### PR DESCRIPTION
Dry run mode was only tried so far with single-node. This commit makes
the IP and hostname configurable, allowing the swarm to launch
multi-node clusters without having hosts clash.

It also disables the connectivity check in dry run mode because with
different fake IP addresses that would obviously not work