### PR TITLE
MGMT-8422: apivip check remove suffix

### DIFF
--- a/src/apivip_check/apivip_check.go
+++ b/src/apivip_check/apivip_check.go
@@ -13,10 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	WorkerIgnitionPath = "/config/worker"
-)
-
 func CheckAPIConnectivity(checkAPIRequestStr string, log logrus.FieldLogger) (stdout string, stderr string, exitCode int) {
 	var checkAPIRequest models.APIVipConnectivityRequest
 
@@ -32,7 +28,7 @@ func CheckAPIConnectivity(checkAPIRequestStr string, log logrus.FieldLogger) (st
 		return createResponse(false), err.Error(), -1
 	}
 
-	if err := httpDownload(*checkAPIRequest.URL + WorkerIgnitionPath); err != nil {
+	if err := httpDownload(*checkAPIRequest.URL); err != nil {
 		wrapped := errors.Wrap(err, "Failed to download worker.ign file")
 		log.WithError(err).Error(wrapped.Error())
 		return createResponse(false), wrapped.Error(), 0

--- a/src/apivip_check/apivip_check_test.go
+++ b/src/apivip_check/apivip_check_test.go
@@ -13,6 +13,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	TestWorkerIgnitionPath = "/config/worker"
+)
+
 var _ = Describe("API connectivity check test", func() {
 	var log logrus.FieldLogger
 	var srv *httptest.Server
@@ -98,7 +102,7 @@ func getRequestStr(url *string, verifyCidr bool) string {
 
 func serverMock(mock func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
 	handler := http.NewServeMux()
-	handler.HandleFunc(WorkerIgnitionPath, mock)
+	handler.HandleFunc(TestWorkerIgnitionPath, mock)
 	srv := httptest.NewServer(handler)
 	return srv
 }

--- a/subsystem/apivip_check_test.go
+++ b/subsystem/apivip_check_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/openshift/assisted-service/models"
 )
 
+const (
+	TestWorkerIgnitionPath = "/config/worker"
+)
+
 var _ = Describe("API VIP connectivity check tests", func() {
 	var (
 		hostID string
@@ -23,7 +27,7 @@ var _ = Describe("API VIP connectivity check tests", func() {
 	})
 
 	It("verify API connectivity", func() {
-		url := WireMockURLFromSubsystemHost
+		url := WireMockURLFromSubsystemHost + TestWorkerIgnitionPath
 		setWorkerIgnitionStub(hostID, &models.APIVipConnectivityRequest{
 			URL: &url,
 		})
@@ -68,13 +72,13 @@ func (i *APIConnectivityCheckVerifier) verify(actualReply *models.StepReply) boo
 }
 
 func addWorkerIgnitionStub() (string, error) {
-	ignitionConfig, err := apivip_check.FormatNodeIgnitionFile(AssistedServiceURLFromAgent + apivip_check.WorkerIgnitionPath)
+	ignitionConfig, err := apivip_check.FormatNodeIgnitionFile(AssistedServiceURLFromAgent + TestWorkerIgnitionPath)
 	if err != nil {
 		return "", err
 	}
 	stub := StubDefinition{
 		Request: &RequestDefinition{
-			URL:    apivip_check.WorkerIgnitionPath,
+			URL:    TestWorkerIgnitionPath,
 			Method: "GET",
 		},
 		Response: &ResponseDefinition{


### PR DESCRIPTION
Assisted Installer Service already add the suffix "config/worker".

Removing in Agent side to avoid to get to this URL:
http://<API IP>:22624/config/worker/config/worker