### PR TITLE
MGMT-8424: Add token and CA cert to API VIP check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
-	github.com/openshift/assisted-service v1.0.10-0.20211121085606-2c0b10ee076f
+	github.com/openshift/assisted-service v1.0.10-0.20211209144019-0e79e608f2b1
 	github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1087,6 +1087,8 @@ github.com/openshift/api v0.0.0-20210216211028-bb81baaf35cd/go.mod h1:aqU5Cq+kqK
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/assisted-service v1.0.10-0.20211121085606-2c0b10ee076f h1:gWVxdxUSWncYGwTOOBffebdwzOznVhPmPMbxtzOvk7I=
 github.com/openshift/assisted-service v1.0.10-0.20211121085606-2c0b10ee076f/go.mod h1:27Z02es7yJUu34pFYCUoxKDySD7/1D0WpuBBmzj4ORg=
+github.com/openshift/assisted-service v1.0.10-0.20211209144019-0e79e608f2b1 h1:Pvs+GVzBjm3KosxQzJ0vWW/JM8ZL4vzEJ/6xMSHy1JI=
+github.com/openshift/assisted-service v1.0.10-0.20211209144019-0e79e608f2b1/go.mod h1:27Z02es7yJUu34pFYCUoxKDySD7/1D0WpuBBmzj4ORg=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd h1:5JV3JearFzKVj+bmc0PPrb1+bbgSye6loMQihlc3JBY=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd/go.mod h1:+duukQisb5LU1bMtLalsHZc1wM69D5sH3TuiyvAQhhA=

--- a/src/apivip_check/apivip_check_test.go
+++ b/src/apivip_check/apivip_check_test.go
@@ -1,10 +1,22 @@
 package apivip_check
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
 
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -15,7 +27,7 @@ import (
 
 const (
 	TestWorkerIgnitionPath = "/config/worker"
-	AcceptHeader = "application/vnd.coreos.ignition+json; version=3.2.0"
+	AcceptHeader           = "application/vnd.coreos.ignition+json; version=3.2.0"
 )
 
 var _ = Describe("API connectivity check test", func() {
@@ -33,7 +45,7 @@ var _ = Describe("API connectivity check test", func() {
 	Context("Ignition file", func() {
 		It("Download ignition file successfully", func() {
 			srv = serverMock(ignitionMock)
-			stdout, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
+			stdout, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false, nil, nil), log)
 			Expect(exitCode).Should(Equal(0))
 			Expect(stderr).Should(BeEmpty())
 			checkResponse(stdout, true)
@@ -41,14 +53,14 @@ var _ = Describe("API connectivity check test", func() {
 
 		It("Invalid ignition file format", func() {
 			srv = serverMock(ignitionMockInvalid)
-			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false, nil, nil), log)
 			Expect(exitCode).Should(Equal(0))
 			Expect(stderr).Should(ContainSubstring("Error unmarshaling Ignition string"))
 		})
 
 		It("Empty ignition", func() {
 			srv = serverMock(ignitionMockEmpty)
-			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL), log)
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false, nil, nil), log)
 			Expect(exitCode).Should(Equal(0))
 			Expect(stderr).Should(Equal("Failed to download worker.ign file: Empty Ignition file"))
 		})
@@ -57,26 +69,82 @@ var _ = Describe("API connectivity check test", func() {
 	Context("API URL", func() {
 		It("Invalid API URL", func() {
 			url := "http://127.0.0.1:2345"
-			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&url), log)
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&url, false, nil, nil), log)
 			Expect(exitCode).Should(Equal(0))
 			Expect(stderr).Should(ContainSubstring("HTTP download failure"))
 		})
 
 		It("Missing API URL", func() {
-			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(nil), log)
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(nil, false, nil, nil), log)
 			Expect(exitCode).Should(Equal(-1))
 			Expect(stderr).Should(Equal("Missing URL in checkAPIRequest"))
+		})
+
+		It("Bearer Token", func() {
+			ignitionToken := "secrettoken"
+			srv = serverMock(bearerIgnitionMock(ignitionToken))
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false, nil, &ignitionToken), log)
+			Expect(exitCode).Should(Equal(0))
+			Expect(stderr).Should(BeEmpty())
+		})
+
+		It("Wrong Bearer Token", func() {
+			ignitionToken := "secrettoken"
+			srv = serverMock(bearerIgnitionMock("anothertoken"))
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false, nil, &ignitionToken), log)
+			Expect(exitCode).Should(Equal(0))
+			Expect(stderr).Should(ContainSubstring("HTTP download failure"))
+		})
+	})
+
+	Context("CA Cert", func() {
+		It("Valid Cert", func() {
+			servConfig, caPEM, err := certsetup()
+			Expect(err).NotTo(HaveOccurred())
+			srv, err = httpsServerMock(servConfig, ignitionMock)
+			Expect(err).NotTo(HaveOccurred())
+			caCert := string(caPEM)
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false, &caCert, nil), log)
+			Expect(exitCode).Should(Equal(0))
+			Expect(stderr).Should(BeEmpty())
+		})
+
+		It("Invalid Cert", func() {
+			servConfig, _, err := certsetup()
+			Expect(err).NotTo(HaveOccurred())
+			srv, err = httpsServerMock(servConfig, ignitionMock)
+			Expect(err).NotTo(HaveOccurred())
+			caCert := "somecert"
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false, &caCert, nil), log)
+			Expect(exitCode).Should(Equal(0))
+			Expect(stderr).Should(ContainSubstring("unable to parse cert"))
+		})
+
+		It("Wrong Cert", func() {
+			_, cert, err := certsetup()
+			Expect(err).NotTo(HaveOccurred())
+			servConfig, _, err := certsetup()
+			Expect(err).NotTo(HaveOccurred())
+			srv, err = httpsServerMock(servConfig, ignitionMock)
+			Expect(err).NotTo(HaveOccurred())
+			wrongCert := string(cert)
+			_, stderr, exitCode := CheckAPIConnectivity(getRequestStr(&srv.URL, false, &wrongCert, nil), log)
+			Expect(exitCode).Should(Equal(0))
+			Expect(stderr).Should(ContainSubstring("unknown authority"))
 		})
 	})
 })
 
-func getRequestStr(url *string) string {
+func getRequestStr(url *string, verifyCidr bool, caCert *string, token *string) string {
 	if url != nil {
 		ignitionURL := *url + TestWorkerIgnitionPath
 		url = &ignitionURL
 	}
 	request := models.APIVipConnectivityRequest{
-		URL: url,
+		URL:                   url,
+		VerifyCidr:            verifyCidr,
+		CaCertificate:         caCert,
+		IgnitionEndpointToken: token,
 	}
 
 	requestBytes, err := json.Marshal(request)
@@ -91,6 +159,18 @@ func serverMock(mock func(w http.ResponseWriter, r *http.Request)) *httptest.Ser
 	handler.HandleFunc(TestWorkerIgnitionPath, mock)
 	srv := httptest.NewServer(handler)
 	return srv
+}
+
+func bearerIgnitionMock(token string) func(w http.ResponseWriter, r *http.Request) {
+	bearerToken := fmt.Sprintf("Bearer %s", token)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != bearerToken {
+			logrus.Error("missing Auth header in request")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		ignitionMock(w, r)
+	}
 }
 
 func ignitionMock(w http.ResponseWriter, r *http.Request) {
@@ -123,4 +203,123 @@ func checkResponse(stdout string, success bool) {
 func TestSubsystem(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "API connectivity check unit tests")
+}
+
+func httpsServerMock(servConfig *tls.Config, mock func(w http.ResponseWriter, r *http.Request)) (*httptest.Server, error) {
+	handler := http.NewServeMux()
+	handler.HandleFunc(TestWorkerIgnitionPath, mock)
+	srv := httptest.NewUnstartedServer(handler)
+	srv.TLS = servConfig
+	srv.StartTLS()
+	return srv, nil
+}
+
+func certsetup() (*tls.Config, []byte, error) {
+	// set up our CA certificate
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization:  []string{"Company, INC."},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"San Francisco"},
+			StreetAddress: []string{"Golden Gate Bridge"},
+			PostalCode:    []string{"94016"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// create our private and public key
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// create the CA
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// pem encode
+	caPEM := new(bytes.Buffer)
+	err = pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caPrivKeyPEM := new(bytes.Buffer)
+	err = pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// set up our server certificate
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization:  []string{"Company, INC."},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"San Francisco"},
+			StreetAddress: []string{"Golden Gate Bridge"},
+			PostalCode:    []string{"94016"},
+		},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := new(bytes.Buffer)
+	err = pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPrivKeyPEM := new(bytes.Buffer)
+	err = pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serverCert, err := tls.X509KeyPair(certPEM.Bytes(), certPrivKeyPEM.Bytes())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serverTLSConf := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	}
+
+	return serverTLSConf, certPEM.Bytes(), nil
 }

--- a/src/commands/connectivity_check.go
+++ b/src/commands/connectivity_check.go
@@ -72,7 +72,7 @@ func l3CheckAddressOnNic(address string, outgoingNic string, innerChan chan *mod
 		RemoteIPAddress: address,
 	}
 
-	if config.GlobalDryRunConfig.DryRunEnabled { 
+	if config.GlobalDryRunConfig.DryRunEnabled {
 		ret.Successful = true
 		ret.PacketLossPercentage = 0.0
 		ret.AverageRTTMs = 0.0

--- a/src/inventory/dry_inventory.go
+++ b/src/inventory/dry_inventory.go
@@ -32,4 +32,3 @@ func findRelevantInterface(inventory *models.Inventory) (int, error) {
 
 	return -1, fmt.Errorf("No suitable interface for dry run reconfiguration found in %+v", inventory.Interfaces)
 }
-


### PR DESCRIPTION
Add support of Authorization token and CA cert to the API VIP connectivity validation.

Depends on https://github.com/openshift/assisted-service/pull/3027