### PR TITLE
MGMT-7428: apivip_check - Accept header in ignition request

### DIFF
--- a/src/apivip_check/apivip_check.go
+++ b/src/apivip_check/apivip_check.go
@@ -2,6 +2,7 @@ package apivip_check
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+const ignitionVersion string = "3.2.0"
 
 func CheckAPIConnectivity(checkAPIRequestStr string, log logrus.FieldLogger) (stdout string, stderr string, exitCode int) {
 	var checkAPIRequest models.APIVipConnectivityRequest
@@ -46,7 +49,16 @@ func createResponse(success bool) string {
 }
 
 func httpDownload(uri string) error {
-	res, err := http.Get(uri)
+	client := http.Client{}
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, "HTTP download - failed to create request")
+	}
+	req.Header = http.Header{
+		"Accept": []string{fmt.Sprintf("application/vnd.coreos.ignition+json; version=%s", ignitionVersion)},
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "HTTP download failure")
 	}


### PR DESCRIPTION
Added 'Accept' to ignition download request header to explicitly specify version 3.2.0.
This is required to avoid a redundant conversion to v2.2[1] and a failure in machine-config-operator when LUKS is enabled[2].

[1] https://github.com/openshift/machine-config-operator/blob/9c6c2bfd7ed498bfbc296d530d1839bd6a177b0b/pkg/server/api.go#L154

[2] error: failed to convert config from spec v3.2 to v2.2: unable to convert Ignition spec v3 config to v2: LUKS is not supported on 2.2