### PR TITLE
MGMT-7428: return ignition in apivip_check response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
-	github.com/openshift/assisted-service v1.0.10-0.20211209144019-0e79e608f2b1
+	github.com/openshift/assisted-service v1.0.10-0.20211220172429-aa87618bd812
 	github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1089,6 +1089,8 @@ github.com/openshift/assisted-service v1.0.10-0.20211121085606-2c0b10ee076f h1:g
 github.com/openshift/assisted-service v1.0.10-0.20211121085606-2c0b10ee076f/go.mod h1:27Z02es7yJUu34pFYCUoxKDySD7/1D0WpuBBmzj4ORg=
 github.com/openshift/assisted-service v1.0.10-0.20211209144019-0e79e608f2b1 h1:Pvs+GVzBjm3KosxQzJ0vWW/JM8ZL4vzEJ/6xMSHy1JI=
 github.com/openshift/assisted-service v1.0.10-0.20211209144019-0e79e608f2b1/go.mod h1:27Z02es7yJUu34pFYCUoxKDySD7/1D0WpuBBmzj4ORg=
+github.com/openshift/assisted-service v1.0.10-0.20211220172429-aa87618bd812 h1:bQwBu5OV5BioSUAGRKD+XO5mwdtrAt6kwHR2DKkTQRo=
+github.com/openshift/assisted-service v1.0.10-0.20211220172429-aa87618bd812/go.mod h1:27Z02es7yJUu34pFYCUoxKDySD7/1D0WpuBBmzj4ORg=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd h1:5JV3JearFzKVj+bmc0PPrb1+bbgSye6loMQihlc3JBY=
 github.com/openshift/baremetal-runtimecfg v0.0.0-20210210163937-34f98e0f48fd/go.mod h1:+duukQisb5LU1bMtLalsHZc1wM69D5sH3TuiyvAQhhA=

--- a/src/apivip_check/apivip_check_test.go
+++ b/src/apivip_check/apivip_check_test.go
@@ -29,6 +29,7 @@ import (
 const (
 	TestWorkerIgnitionPath = "/config/worker"
 	AcceptHeader           = "application/vnd.coreos.ignition+json; version=3.2.0"
+	IgnitionSource         = "http://127.0.0.1:1234"
 )
 
 var _ = Describe("API connectivity check test", func() {
@@ -180,7 +181,7 @@ func ignitionMock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ignitionConfig, err := FormatNodeIgnitionFile("http://127.0.0.1:1234")
+	ignitionConfig, err := FormatNodeIgnitionFile(IgnitionSource)
 	if err != nil {
 		return
 	}
@@ -199,6 +200,12 @@ func checkResponse(stdout string, success bool) {
 	var response models.APIVipConnectivityResponse
 	Expect(json.Unmarshal([]byte(stdout), &response)).ToNot(HaveOccurred())
 	Expect(success).To(Equal(response.IsSuccess))
+
+	if success {
+		ignition, err := FormatNodeIgnitionFile(IgnitionSource)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(ignition)).To(Equal(response.Ignition))
+	}
 }
 
 func TestSubsystem(t *testing.T) {


### PR DESCRIPTION
Return ignition as part of APIVipConnectivityResponse for exposing LUKS (disk encryption) information to the
service. This is required as part of disk encryption validation for day2 hosts.

Note: pending on swagger change - https://github.com/openshift/assisted-service/pull/3073