### PR TITLE
MGMT-8847: Add bf serial value to unknown serials in agent

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1085,10 +1085,6 @@ github.com/openshift/api v0.0.0-20200901182017-7ac89ba6b971/go.mod h1:M3xexPhgM8
 github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267/go.mod h1:RDvBcRQMGLa3aNuDuejVBbTEQj/2i14NXdpOLqbNBvM=
 github.com/openshift/api v0.0.0-20210216211028-bb81baaf35cd/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
-github.com/openshift/assisted-service v1.0.10-0.20211121085606-2c0b10ee076f h1:gWVxdxUSWncYGwTOOBffebdwzOznVhPmPMbxtzOvk7I=
-github.com/openshift/assisted-service v1.0.10-0.20211121085606-2c0b10ee076f/go.mod h1:27Z02es7yJUu34pFYCUoxKDySD7/1D0WpuBBmzj4ORg=
-github.com/openshift/assisted-service v1.0.10-0.20211209144019-0e79e608f2b1 h1:Pvs+GVzBjm3KosxQzJ0vWW/JM8ZL4vzEJ/6xMSHy1JI=
-github.com/openshift/assisted-service v1.0.10-0.20211209144019-0e79e608f2b1/go.mod h1:27Z02es7yJUu34pFYCUoxKDySD7/1D0WpuBBmzj4ORg=
 github.com/openshift/assisted-service v1.0.10-0.20211220172429-aa87618bd812 h1:bQwBu5OV5BioSUAGRKD+XO5mwdtrAt6kwHR2DKkTQRo=
 github.com/openshift/assisted-service v1.0.10-0.20211220172429-aa87618bd812/go.mod h1:27Z02es7yJUu34pFYCUoxKDySD7/1D0WpuBBmzj4ORg=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=

--- a/src/apivip_check/apivip_check.go
+++ b/src/apivip_check/apivip_check.go
@@ -3,11 +3,11 @@ package apivip_check
 import (
 	"crypto/tls"
 	"crypto/x509"
+	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	b64 "encoding/base64"
 
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -42,8 +42,14 @@ var _ = Describe("Machine uuid test", func() {
 		id := ReadId(serialDiscovery)
 		Expect(id).To(Equal(toUUID(TestUuid)))
 	})
-	It("Vmware None", func() {
-		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: VmwareDefaultSerial}, nil).Once()
+	It("Vmware None serial", func() {
+		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "None"}, nil).Once()
+		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
+		id := ReadId(serialDiscovery)
+		Expect(id).To(Equal(toUUID(TestUuid)))
+	})
+	It("unspecified serial", func() {
+		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "Unspecified Base Board Serial Number"}, nil).Once()
 		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
 		id := ReadId(serialDiscovery)
 		Expect(id).To(Equal(toUUID(TestUuid)))


### PR DESCRIPTION
 In BF cards there is know serial of mother board and we get "Unspecified Base Board Serial Number" ,
we should take systemuuid in that case