### PR TITLE
MGMT-8481: Allow fallback for generate uuid from mac for kaloom deployment

### DIFF
--- a/src/commands/service_api.go
+++ b/src/commands/service_api.go
@@ -5,6 +5,7 @@ import (
 	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-installer-agent/src/scanners"
 	"github.com/openshift/assisted-installer-agent/src/session"
+	agent_utils "github.com/openshift/assisted-installer-agent/src/util"
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/models"
 )
@@ -20,7 +21,7 @@ type v2ServiceAPI struct{}
 func (v *v2ServiceAPI) RegisterHost(s *session.InventorySession) (*models.HostRegistrationResponse, error) {
 	var hostID strfmt.UUID = strfmt.UUID("")
 	if !config.GlobalDryRunConfig.DryRunEnabled {
-		hostID = *scanners.ReadId(scanners.NewGHWSerialDiscovery())
+		hostID = *scanners.ReadId(scanners.NewGHWSerialDiscovery(), agent_utils.NewDependencies(""))
 	} else {
 		hostID = strfmt.UUID(config.GlobalDryRunConfig.ForcedHostID)
 	}

--- a/src/scanners/machine_uuid_scanner.go
+++ b/src/scanners/machine_uuid_scanner.go
@@ -94,7 +94,7 @@ func (ir *idReader) readMotherboardSerial() *strfmt.UUID {
 	return md5GenerateUUID(basedboard.SerialNumber)
 }
 
-func ReadId(d SerialDiscovery) *strfmt.UUID {
+func ReadId(d SerialDiscovery, dependencies agent_utils.IDependencies) *strfmt.UUID {
 	ir := &idReader{serialDiscovery: d}
 	ret := ir.readMotherboardSerial()
 	if ret == nil {
@@ -103,7 +103,7 @@ func ReadId(d SerialDiscovery) *strfmt.UUID {
 	}
 	if ret == nil {
 		log.Warn("No valid serial for mother board and  system UUID  moving to interface mac")
-		interfaces := inventory.GetInterfaces(agent_utils.NewDependencies(""))
+		interfaces := inventory.GetInterfaces(dependencies)
 		// sort by mac
 		sort.Slice(interfaces, func(i, j int) bool {
 			return interfaces[i].MacAddress < interfaces[j].MacAddress

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -1,6 +1,9 @@
 package scanners
 
 import (
+	"github.com/openshift/assisted-installer-agent/src/inventory"
+	agent_utils "github.com/openshift/assisted-installer-agent/src/util"
+	"sort"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -53,6 +56,16 @@ var _ = Describe("Machine uuid test", func() {
 		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
 		id := ReadId(serialDiscovery)
 		Expect(id).To(Equal(toUUID(TestUuid)))
+	})
+	It("default string serial and system uuid", func() {
+		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "Default string"}, nil).Once()
+		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: "Default string"}, nil)
+		id := ReadId(serialDiscovery)
+		interfaces := inventory.GetInterfaces(agent_utils.NewDependencies(""))
+		sort.Slice(interfaces, func(i, j int) bool {
+			return interfaces[i].MacAddress < interfaces[j].MacAddress
+		})
+		Expect(id).To(Equal(md5GenerateUUID(interfaces[0].MacAddress)))
 	})
 	It("Other", func() {
 		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "Other"}, nil).Once()

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -1,10 +1,15 @@
 package scanners
 
 import (
-	"github.com/openshift/assisted-installer-agent/src/inventory"
-	agent_utils "github.com/openshift/assisted-installer-agent/src/util"
-	"sort"
+	"errors"
+	"net"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	agentutils "github.com/openshift/assisted-installer-agent/src/util"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/jaypipes/ghw"
@@ -24,8 +29,10 @@ func toUUID(s string) *strfmt.UUID {
 
 var _ = Describe("Machine uuid test", func() {
 	var serialDiscovery *MockSerialDiscovery
+	var dependencies *agentutils.MockIDependencies
 
 	BeforeEach(func() {
+		dependencies = &agentutils.MockIDependencies{}
 		serialDiscovery = &MockSerialDiscovery{}
 	})
 
@@ -36,40 +43,57 @@ var _ = Describe("Machine uuid test", func() {
 	It("Empty serial", func() {
 		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{}, nil).Once()
 		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
-		id := ReadId(serialDiscovery)
+		id := ReadId(serialDiscovery, dependencies)
 		Expect(id).To(Equal(toUUID(TestUuid)))
 	})
 	It("Unknown serial", func() {
 		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: util.UNKNOWN}, nil).Once()
 		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
-		id := ReadId(serialDiscovery)
+		id := ReadId(serialDiscovery, dependencies)
 		Expect(id).To(Equal(toUUID(TestUuid)))
 	})
 	It("Vmware None serial", func() {
 		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "None"}, nil).Once()
 		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
-		id := ReadId(serialDiscovery)
+		id := ReadId(serialDiscovery, dependencies)
 		Expect(id).To(Equal(toUUID(TestUuid)))
 	})
 	It("unspecified serial", func() {
 		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "Unspecified Base Board Serial Number"}, nil).Once()
 		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
-		id := ReadId(serialDiscovery)
+		id := ReadId(serialDiscovery, dependencies)
 		Expect(id).To(Equal(toUUID(TestUuid)))
 	})
 	It("default string serial and system uuid", func() {
+		rets := []agentutils.Interface{
+			agentutils.NewFilledInterfaceMock(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "192.168.6.7/20", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, true, false, false, 100),
+			agentutils.NewFilledInterfaceMock(1400, "eth1", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.19/24", "192.168.6.8/20", "fe80::d832:8def:dd51:3528/127", "de90::d832:8def:dd51:3528/127"}, true, false, false, 10),
+		}
+		dependencies.On("Interfaces").Return(rets, nil).Once()
+		dependencies.On("Execute", "biosdevname", "-i", "eth0").Return("em2", "", 0).Once()
+		dependencies.On("ReadFile", "/sys/class/net/eth0/carrier").Return([]byte("0\n"), nil).Once()
+		dependencies.On("ReadFile", "/sys/class/net/eth0/device/device").Return([]byte("my-device1"), nil).Once()
+		dependencies.On("ReadFile", "/sys/class/net/eth0/device/vendor").Return([]byte("my-vendor1"), nil).Once()
+		dependencies.On("Execute", "biosdevname", "-i", "eth1").Return("em3", "", 0).Once()
+		dependencies.On("ReadFile", "/sys/class/net/eth1/carrier").Return(nil, errors.New("Blah")).Once()
+		dependencies.On("ReadFile", "/sys/class/net/eth1/device/device").Return(nil, errors.New("Blah")).Once()
+		dependencies.On("ReadFile", "/sys/class/net/eth1/device/vendor").Return([]byte("my-vendor2"), nil).Once()
+		dependencies.On("LinkByName", mock.Anything).Return(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}, nil)
+		dependencies.On("RouteList", mock.Anything, mock.Anything).Return([]netlink.Route{
+			{
+				Dst:      &net.IPNet{IP: net.ParseIP("de90::"), Mask: net.CIDRMask(64, 128)},
+				Protocol: unix.RTPROT_RA,
+			},
+		}, nil)
+
 		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "Default string"}, nil).Once()
 		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: "Default string"}, nil)
-		id := ReadId(serialDiscovery)
-		interfaces := inventory.GetInterfaces(agent_utils.NewDependencies(""))
-		sort.Slice(interfaces, func(i, j int) bool {
-			return interfaces[i].MacAddress < interfaces[j].MacAddress
-		})
-		Expect(id).To(Equal(md5GenerateUUID(interfaces[0].MacAddress)))
+		id := ReadId(serialDiscovery, dependencies)
+		Expect(id).To(Equal(md5GenerateUUID("f8:75:a4:a4:00:fe")))
 	})
 	It("Other", func() {
 		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "Other"}, nil).Once()
-		id := ReadId(serialDiscovery)
+		id := ReadId(serialDiscovery, dependencies)
 		Expect(id).To(Equal(toUUID("6311ae17-c1ee-52b3-6e68-aaf4ad066387")))
 	})
 })


### PR DESCRIPTION
[MGMT-8481](https://issues.redhat.com/browse/MGMT-9003): Allow fallback for generate uuid from mac for kaloom deployment
Currently kaloom are not able to deploy multinode cluster as their machines generates same uuid as serial uuid and mother board uuid has "Default string" value
We want to create quick fix till we fully move to using macs