### PR TITLE
NO-ISSUE: fix dependabot commit messages to include NO-ISSUE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       - "ok-to-test"
       - "go"
       - "dependencies"
+    commit-message:
+      prefix: "NO-ISSUE"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
To make dependabot PRs pass lint job, we need commit messages to start with ``NO-ISSUE``.
/cc @filanov 