### PR TITLE
MGMT-8752: handle ocp router 503 errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/coreos/ignition/v2 v2.13.0
+	github.com/go-openapi/runtime v0.19.24
 	github.com/go-openapi/strfmt v0.21.1
 	github.com/go-openapi/swag v0.19.15
 	github.com/google/uuid v1.3.0

--- a/src/commands/errors.go
+++ b/src/commands/errors.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/models"
+)
+
+func getErrorMessage(err error) (message string) {
+	getPayload := reflect.ValueOf(err).MethodByName("GetPayload")
+	if (getPayload != reflect.Value{}) {
+		pt := getPayload.Call([]reflect.Value{})[0]
+		if cause, ok := pt.Interface().(*models.Error); ok {
+			if cause.Code != nil {
+				message = fmt.Sprintf("[%s] ", *cause.Code)
+			}
+			message = fmt.Sprintf("%s%s", message, swag.StringValue(cause.Reason))
+		}
+		if cause, ok := pt.Interface().(*models.InfraError); ok {
+			if cause.Code != nil {
+				message = fmt.Sprintf("[%d] ", *cause.Code)
+			}
+			message = fmt.Sprintf("%s%s", message, swag.StringValue(cause.Message))
+		}
+	} else {
+		message = err.Error()
+	}
+	return
+}


### PR DESCRIPTION
The OCP router sends a 503 response with a standard HTML formatted message when the service is down.

However, the go client generated by swagger expects a JSON-formatted API message and fails to analyze the response body. The result is an unclear error message in the agent, installer, and controller when the service is down.

Based on the recommended course of action this PR replaces the consumer of text/html responses to handle all sort of embedded responses (Both text, openshift and assisted-service generated errors) so all possible 503 (and other general responses) will be covered. Since BE errors are not printed well with the generic Error() function in case of embedded reason, it also put forward a marshaling code for all sort of errors, so in all cases the logs will be informative.