### PR TITLE
MGMT-7813 Reduce smartcl verbosity

### DIFF
--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -136,7 +136,7 @@ func (d *disks) getSMART(path string) string {
 	// We ignore the exit code and stderr because stderr is empty and
 	// stdout contains the exit code in `--json=c` mode. Whatever the exit
 	// code is, we want to relay the information to the service
-	stdout, _, _ := d.dependencies.Execute("smartctl", "--xall", "--json=c", path)
+	stdout, _, _ := d.dependencies.Execute("smartctl", "--all", "--json=c", path)
 
 	return stdout
 }

--- a/src/inventory/disks_test.go
+++ b/src/inventory/disks_test.go
@@ -303,7 +303,7 @@ func mockGetBootable(dependencies *util.MockIDependencies, path string, bootable
 }
 
 func mockGetSMART(dependencies *util.MockIDependencies, path string, err string) *mock.Call {
-	return mockExecuteDependencyCall(dependencies, "smartctl", `{"some": "json"}`, err, "--xall", "--json=c", path)
+	return mockExecuteDependencyCall(dependencies, "smartctl", `{"some": "json"}`, err, "--all", "--json=c", path)
 }
 
 func mockAllForSuccess(dependencies *util.MockIDependencies, disks ...*ghw.Disk) {
@@ -417,8 +417,8 @@ var _ = Describe("Disks test", func() {
 		})
 
 		It("With a smartctl error - make sure JSON is still transmitted", func() {
-			Expect(util.DeleteExpectedMethod(&dependencies.Mock, "Execute", "smartctl", "--xall", "--json=c", "/dev/foo/disk1")).To(BeTrue())
-			dependencies.On("Execute", "smartctl", "--xall", "--json=c", "/dev/foo/disk1").Return(`{"some": "json"}`, "", 1).Once()
+			Expect(util.DeleteExpectedMethod(&dependencies.Mock, "Execute", "smartctl", "--all", "--json=c", "/dev/foo/disk1")).To(BeTrue())
+			dependencies.On("Execute", "smartctl", "--all", "--json=c", "/dev/foo/disk1").Return(`{"some": "json"}`, "", 1).Once()
 			expectation[0].Smart = `{"some": "json"}`
 		})
 


### PR DESCRIPTION
The agent currently returns `smartctl --xall` which returns lots of
information, some of which isn't SMART.

Let's change to `--all` instead of `--xall`.