### PR TITLE
NO-ISSUE: Dockerfile: don't install docs and weak dependencies

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -16,7 +16,7 @@ FROM quay.io/centos/centos:stream8
 ARG TARGETPLATFORM
 RUN if [[ "$TARGETPLATFORM" == "linux/amd64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y biosdevname ; fi
 
-RUN dnf install -y \
+RUN dnf install --setopt=install_weak_deps=False --setopt=tsdocs=False -y \
 		findutils iputils \
 		podman \
 		# inventory
@@ -31,7 +31,7 @@ RUN dnf install -y \
 		tar openssh-clients \
 		# ntp_synchronizer
 		chrony \
-		&& dnf update -y systemd && dnf clean all
+		&& dnf update --setopt=install_weak_deps=False --setopt=tsdocs=False -y systemd && dnf clean all && rm -rf /var/cache
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/agent /usr/bin/agent
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/free_addresses /usr/bin/free_addresses


### PR DESCRIPTION
This shaves off ~50Mb from final container size:
```
$ podman images | grep quay.io/vrutkovs/assisted-installer-agent                                               
quay.io/vrutkovs/assisted-installer-agent                slim-agent              869abe541647  16 seconds ago      948 MB
quay.io/vrutkovs/assisted-installer-agent                master                  558e0ee6bd54  22 minutes ago      1.04 GB
```