### PR TITLE
MGMT-9396: Fix UUID fallback

### DIFF
--- a/src/apivip_check/apivip_check_test.go
+++ b/src/apivip_check/apivip_check_test.go
@@ -19,8 +19,8 @@ import (
 	"math/big"
 	"time"
 
-	v32_types "github.com/coreos/ignition/v2/config/v3_2/types"
 	v31_types "github.com/coreos/ignition/v2/config/v3_1/types"
+	v32_types "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 

--- a/src/scanners/machine_uuid_scanner.go
+++ b/src/scanners/machine_uuid_scanner.go
@@ -18,11 +18,17 @@ import (
 )
 
 const (
-	DefaultUUID = "00000000-0000-0000-0000-000000000000"
+	SerialDefaultString              = "default string"
+	SerialUnspecifiedBaseBoardString = "unspecified base board serial number" // BF cards
+	SerialUnspecifiedSystemString    = "unspecified system serial number"     // BF cards
+	ZeroesUUID                       = "00000000-0000-0000-0000-000000000000"
+	KaloomUUID                       = "03000200-0400-0500-0006-000700080009" // All hosts of this type have the same UUID
 )
 
 var unknownSerialCases = []string{"", util.UNKNOWN, "none",
-	"unspecified base board serial number", "default string"}
+	SerialUnspecifiedBaseBoardString, SerialUnspecifiedSystemString,
+	SerialDefaultString}
+var unknownUuidCases = []string{"", util.UNKNOWN, ZeroesUUID, KaloomUUID}
 
 func disableGHWWarnings() {
 	err := os.Setenv("GHW_DISABLE_WARNINGS", "1")
@@ -71,7 +77,7 @@ func (ir *idReader) readSystemUUID() *strfmt.UUID {
 		value = product.UUID
 	}
 
-	if funk.Contains(unknownSerialCases, strings.ToLower(value)) {
+	if funk.Contains(unknownUuidCases, strings.ToLower(value)) {
 		log.Warnf("Could not get system UUID. Got %s", value)
 		return nil
 	}


### PR DESCRIPTION
If the system's UUID is a special case, we fall back to using the MAC
address instead. We mistakenly used the same special cases for both
motherboard serial and UUID. This commit separates the special cases and
adds the special UUIDs for two hardware types.