### PR TITLE
MGMT-9344: Return non-zero exit when subsystem test fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,15 @@ endif
 unit-test:
 	$(MAKE) _test TEST_SCENARIO=unit TIMEOUT=30m TEST="$(or $(TEST),$(shell go list ./... | grep -v subsystem))" || (docker kill postgres && /bin/false)
 
-subsystem: build-image
-	-docker image rm subsystem_agent
-	$(DOCKER_COMPOSE) up --build -d dhcpd wiremock
-	-$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=30m TEST="$(or $(TEST),./subsystem/...)"
-	$(DOCKER_COMPOSE) logs dhcpd > dhcpd.log
-	$(DOCKER_COMPOSE) logs wiremock > wiremock.log
-	$(DOCKER_COMPOSE) down
+subsystem: build-image 
+	docker image rm subsystem_agent; \
+	$(DOCKER_COMPOSE) up --build -d dhcpd wiremock; \
+	$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=30m TEST="$(or $(TEST),./subsystem/...)"; \
+	rc=$$?; \
+	$(DOCKER_COMPOSE) logs dhcpd > dhcpd.log; \
+	$(DOCKER_COMPOSE) logs wiremock > wiremock.log; \
+	$(DOCKER_COMPOSE) down; \
+	exit $$rc;
 
 generate:
 	find "${ROOT_DIR}" -name 'mock_*.go' -type f -delete


### PR DESCRIPTION
As part of moving the subsystem test to prow, we need to know when the
step that runs the test fails.
