### PR TITLE
NO-ISSUE: Don't delete the subsystem_agent docker-compose image every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ unit-test:
 	$(MAKE) _test TEST_SCENARIO=unit TIMEOUT=30m TEST="$(or $(TEST),$(shell go list ./... | grep -v subsystem))" || (docker kill postgres && /bin/false)
 
 subsystem: build-image 
-	docker image rm subsystem_agent; \
 	$(DOCKER_COMPOSE) up --build -d dhcpd wiremock; \
 	$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=30m TEST="$(or $(TEST),./subsystem/...)"; \
 	rc=$$?; \


### PR DESCRIPTION
The original commit/PR doesn't mention why it's done. It takes a long time to
build this image and it's annoying to wait for it when you just want to iterate
on a few short tests

The Dockerfile should take care of updating the image if things change, we can
rely on its cache, I can't come up with a good reason to delete it

Original PR: https://github.com/openshift/assisted-installer-agent/pull/219
Original commit: bda33e2f2fc9f6f04d46d6ac90d4f04a32604517