### PR TITLE
NO-ISSUE: add ci operator file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.16


### PR DESCRIPTION
It will enable to override the default dcoker that is used in the CI so
we will not need to make changes in severl palces