### PR TITLE
NO-ISSUE: remove .ci-operator.yaml file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,3 +1,0 @@
-build_root:
-  project_image:
-    dockerfile_path: Dockerfile.assisted_installer_agent-build


### PR DESCRIPTION
It doesn't support pinting to a local file so the upgrade will be done
in several steps
1. update local golang version without code changes
2. update releases to a new golang verison
3. push pr for code changes