### PR TITLE
NO-ISSUE: Pass agent image name to subsystem docker file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,9 @@ endif
 unit-test:
 	$(MAKE) _test TEST_SCENARIO=unit TIMEOUT=30m TEST="$(or $(TEST),$(shell go list ./... | grep -v subsystem))" || (docker kill postgres && /bin/false)
 
-subsystem: build-image 
-	$(DOCKER_COMPOSE) up --build -d dhcpd wiremock; \
+subsystem: build-image
+	$(DOCKER_COMPOSE) build --build-arg ASSISTED_INSTALLER_AGENT=$(ASSISTED_INSTALLER_AGENT) agent || exit 1 ; \
+	$(DOCKER_COMPOSE) up -d dhcpd wiremock; \
 	$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=30m TEST="$(or $(TEST),./subsystem/...)"; \
 	rc=$$?; \
 	$(DOCKER_COMPOSE) logs dhcpd > dhcpd.log; \

--- a/subsystem/Dockerfile.agent_test
+++ b/subsystem/Dockerfile.agent_test
@@ -1,4 +1,5 @@
-FROM quay.io/ocpmetal/assisted-installer-agent:latest
+ARG ASSISTED_INSTALLER_AGENT=quay.io/edge-infrastructure/assisted-installer-agent:latest
+FROM $ASSISTED_INSTALLER_AGENT
 
 RUN yum install -y yum-utils \
     && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \

--- a/subsystem/agent_test.go
+++ b/subsystem/agent_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Agent tests", func() {
 		verifyRegisterRequest()
 		verifyGetNextRequest(hostID, true)
 		expectedReply := &EqualReplyVerifier{
-			Error:    "Missing command",
+			Error:    "failed to find action for step type Step-not-exists",
 			ExitCode: -1,
 			Output:   "",
 			StepID:   stepID,


### PR DESCRIPTION
- Agent image can be passed as environment variable while running make
  command. When this changes, it has to be used in the subsystem as
  well.  This change passes this variable as argument to docker build.

/cc @tsorya 