### PR TITLE
MGMT-9854: Eliminate use of global variables, and use context variables instead

### DIFF
--- a/src/agent/main/main.go
+++ b/src/agent/main/main.go
@@ -7,9 +7,9 @@ import (
 )
 
 func main() {
-	config.ProcessArgs()
-	config.ProcessDryRunArgs()
-	util.SetLogging("agent_registration", config.GlobalAgentConfig.TextLogging, config.GlobalAgentConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
+	agentConfig := config.ProcessArgs()
+	config.ProcessDryRunArgs(&agentConfig.DryRunConfig)
+	util.SetLogging("agent_registration", agentConfig.TextLogging, agentConfig.JournalLogging, agentConfig.ForcedHostID)
 	nextStepRunnerFactory := agent.NewNextStepRunnerFactory()
-	agent.RunAgent(nextStepRunnerFactory)
+	agent.RunAgent(agentConfig, nextStepRunnerFactory)
 }

--- a/src/apivip_check/main/main.go
+++ b/src/apivip_check/main/main.go
@@ -13,9 +13,9 @@ import (
 )
 
 func main() {
-	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
-	config.ProcessDryRunArgs()
-	util.SetLogging("apivip_check", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
+	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
+	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
+	util.SetLogging("apivip_check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Warnf("Expecting exactly single argument to apivip_check. Received %d", len(os.Args)-1)
 		os.Exit(-1)

--- a/src/commands/actions/action.go
+++ b/src/commands/actions/action.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/spf13/afero"
 
 	"github.com/go-openapi/runtime"
@@ -45,20 +46,20 @@ func validateCommon(name string, expectedArgsLength int, args []string, modelToV
 	return nil
 }
 
-func New(stepType models.StepType, args []string) (*Action, error) {
+func New(agentConfig *config.AgentConfig, stepType models.StepType, args []string) (*Action, error) {
 	var stepActionMap = map[models.StepType]*Action{
-		models.StepTypeInventory:                  {&inventory{args: args}},
-		models.StepTypeConnectivityCheck:          {&connectivityCheck{args: args}},
-		models.StepTypeFreeNetworkAddresses:       {&freeAddresses{args: args}},
-		models.StepTypeNtpSynchronizer:            {&ntpSynchronizer{args: args}},
-		models.StepTypeInstallationDiskSpeedCheck: {&diskPerfCheck{args: args}},
+		models.StepTypeInventory:                  {&inventory{args: args, agentConfig: agentConfig}},
+		models.StepTypeConnectivityCheck:          {&connectivityCheck{args: args, agentConfig: agentConfig}},
+		models.StepTypeFreeNetworkAddresses:       {&freeAddresses{args: args, agentConfig: agentConfig}},
+		models.StepTypeNtpSynchronizer:            {&ntpSynchronizer{args: args, agentConfig: agentConfig}},
+		models.StepTypeInstallationDiskSpeedCheck: {&diskPerfCheck{args: args, agentConfig: agentConfig}},
 		models.StepTypeAPIVipConnectivityCheck:    {&apiVipConnectivityCheck{args: args}},
 		models.StepTypeDhcpLeaseAllocate:          {&dhcpLeases{args: args}},
 		models.StepTypeDomainResolution:           {&domainResolution{args: args}},
-		models.StepTypeContainerImageAvailability: {&imageAvailability{args: args}},
+		models.StepTypeContainerImageAvailability: {&imageAvailability{args: args, agentConfig: agentConfig}},
 		models.StepTypeStopInstallation:           {&stopInstallation{args: args}},
-		models.StepTypeLogsGather:                 {&logsGather{args: args}},
-		models.StepTypeInstall:                    {&install{args: args, filesystem: afero.NewOsFs()}},
+		models.StepTypeLogsGather:                 {&logsGather{args: args, agentConfig: agentConfig}},
+		models.StepTypeInstall:                    {&install{args: args, filesystem: afero.NewOsFs(), agentConfig: agentConfig}},
 	}
 
 	action, ok := stepActionMap[stepType]

--- a/src/commands/actions/api_vip_connectivity_check_test.go
+++ b/src/commands/actions/api_vip_connectivity_check_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -15,17 +16,17 @@ func TestActions(t *testing.T) {
 
 func badParamsCommonTests(stepType models.StepType, params []string) {
 	By("bad command")
-	_, err := New(stepType, []string{"echo aaaa"})
+	_, err := New(&config.AgentConfig{}, stepType, []string{"echo aaaa"})
 	Expect(err).To(HaveOccurred())
 
 	if len(params) > 0 {
 		By("Less then 1")
-		_, err = New(stepType, []string{})
+		_, err = New(&config.AgentConfig{}, stepType, []string{})
 		Expect(err).To(HaveOccurred())
 	}
 
 	By("More then expected")
-	_, err = New(stepType, append(params, "aaaa"))
+	_, err = New(&config.AgentConfig{}, stepType, append(params, "aaaa"))
 	Expect(err).To(HaveOccurred())
 }
 
@@ -37,7 +38,7 @@ var _ = Describe("api connectivity check", func() {
 	})
 
 	It("api connectivity cmd", func() {
-		_, err := New(models.StepTypeAPIVipConnectivityCheck, []string{param})
+		_, err := New(&config.AgentConfig{}, models.StepTypeAPIVipConnectivityCheck, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/src/commands/actions/connectivity_check_cmd.go
+++ b/src/commands/actions/connectivity_check_cmd.go
@@ -1,12 +1,14 @@
 package actions
 
 import (
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-installer-agent/src/connectivity_check"
 	"github.com/openshift/assisted-service/models"
 )
 
 type connectivityCheck struct {
-	args []string
+	agentConfig *config.AgentConfig
+	args        []string
 }
 
 func (a *connectivityCheck) Validate() error {
@@ -28,5 +30,5 @@ func (a *connectivityCheck) Args() []string {
 }
 
 func (a *connectivityCheck) Run() (stdout, stderr string, exitCode int) {
-	return connectivity_check.ConnectivityCheck("", a.args...)
+	return connectivity_check.ConnectivityCheck(&a.agentConfig.DryRunConfig, "", a.args...)
 }

--- a/src/commands/actions/connectivity_check_cmd_test.go
+++ b/src/commands/actions/connectivity_check_cmd_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -20,7 +21,7 @@ var _ = Describe("connectivity check", func() {
 	})
 
 	It("connectivity cmd", func() {
-		_, err := New(models.StepTypeConnectivityCheck, []string{param})
+		_, err := New(&config.AgentConfig{}, models.StepTypeConnectivityCheck, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/src/commands/actions/dhcp_leases_cmd_test.go
+++ b/src/commands/actions/dhcp_leases_cmd_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -14,7 +15,7 @@ var _ = Describe("dhcp leases", func() {
 	})
 
 	It("dhcp leases", func() {
-		_, err := New(models.StepTypeDhcpLeaseAllocate, []string{param})
+		_, err := New(&config.AgentConfig{}, models.StepTypeDhcpLeaseAllocate, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/src/commands/actions/disk_perfomance_check_cmd.go
+++ b/src/commands/actions/disk_perfomance_check_cmd.go
@@ -12,7 +12,8 @@ import (
 )
 
 type diskPerfCheck struct {
-	args []string
+	args        []string
+	agentConfig *config.AgentConfig
 }
 
 func (a *diskPerfCheck) Validate() error {
@@ -41,7 +42,7 @@ func (a *diskPerfCheck) Args() []string {
 			fmt.Sprintf("timeout %s ", a.args[1]) +
 			"podman run --privileged --rm --quiet -v /dev:/dev:rw -v /var/log:/var/log -v /run/systemd/journal/socket:/run/systemd/journal/socket " +
 			"--name disk_performance " +
-			config.GlobalAgentConfig.AgentVersion + " disk_speed_check '" +
+			a.agentConfig.AgentVersion + " disk_speed_check '" +
 			a.args[0] + "'",
 	}
 	return arguments

--- a/src/commands/actions/disk_perfomance_check_test.go
+++ b/src/commands/actions/disk_perfomance_check_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -18,7 +19,7 @@ var _ = Describe("dhcp leases", func() {
 	})
 
 	It("disk performance", func() {
-		action, err := New(models.StepTypeInstallationDiskSpeedCheck, []string{param, timeout})
+		action, err := New(&config.AgentConfig{}, models.StepTypeInstallationDiskSpeedCheck, []string{param, timeout})
 		Expect(err).NotTo(HaveOccurred())
 
 		args := action.Args()
@@ -37,19 +38,19 @@ var _ = Describe("dhcp leases", func() {
 
 	It("disk performance input failures", func() {
 		By("bad model")
-		_, err := New(models.StepTypeInstallationDiskSpeedCheck, []string{"echo aaaa", timeout})
+		_, err := New(&config.AgentConfig{}, models.StepTypeInstallationDiskSpeedCheck, []string{"echo aaaa", timeout})
 		Expect(err).To(HaveOccurred())
 
 		By("bad timeout")
-		_, err = New(models.StepTypeInstallationDiskSpeedCheck, []string{param, "aaaaa"})
+		_, err = New(&config.AgentConfig{}, models.StepTypeInstallationDiskSpeedCheck, []string{param, "aaaaa"})
 		Expect(err).To(HaveOccurred())
 
 		By("One arg")
-		_, err = New(models.StepTypeInstallationDiskSpeedCheck, []string{param})
+		_, err = New(&config.AgentConfig{}, models.StepTypeInstallationDiskSpeedCheck, []string{param})
 		Expect(err).To(HaveOccurred())
 
 		By("Three args")
-		_, err = New(models.StepTypeInstallationDiskSpeedCheck, []string{param, timeout, "aaa"})
+		_, err = New(&config.AgentConfig{}, models.StepTypeInstallationDiskSpeedCheck, []string{param, timeout, "aaa"})
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/src/commands/actions/domain_resolution_cmd_test.go
+++ b/src/commands/actions/domain_resolution_cmd_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -16,20 +17,20 @@ var _ = Describe("domain resolution", func() {
 	})
 
 	It("domain resolution", func() {
-		_, err := New(models.StepTypeDomainResolution, []string{param})
+		_, err := New(&config.AgentConfig{}, models.StepTypeDomainResolution, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("domain resolution - bad domain name", func() {
 		param = "{\"domains\":[{\"domain_name\":\"aaaaaa\"}]}"
-		_, err := New(models.StepTypeDomainResolution, []string{param})
+		_, err := New(&config.AgentConfig{}, models.StepTypeDomainResolution, []string{param})
 		Expect(err).To(HaveOccurred())
 
 	})
 
 	It("domain resolution - bad domain name with subcommand", func() {
 		param = "{\"domains\":[{\"domain_name\":\"api.test.test.com;echo\"}]}"
-		_, err := New(models.StepTypeDomainResolution, []string{param})
+		_, err := New(&config.AgentConfig{}, models.StepTypeDomainResolution, []string{param})
 		Expect(err).To(HaveOccurred())
 	})
 

--- a/src/commands/actions/free_addresses_cmd.go
+++ b/src/commands/actions/free_addresses_cmd.go
@@ -10,7 +10,8 @@ import (
 )
 
 type freeAddresses struct {
-	args []string
+	args        []string
+	agentConfig *config.AgentConfig
 }
 
 func (a *freeAddresses) Validate() error {
@@ -34,7 +35,7 @@ func (a *freeAddresses) Args() []string {
 		"--name", containerName,
 		"-v", "/var/log:/var/log",
 		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
-		config.GlobalAgentConfig.AgentVersion,
+		a.agentConfig.AgentVersion,
 		"free_addresses",
 	}
 

--- a/src/commands/actions/free_addresses_cmd_test.go
+++ b/src/commands/actions/free_addresses_cmd_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -16,7 +17,7 @@ var _ = Describe("free addresses", func() {
 	})
 
 	It("free addresses", func() {
-		action, err := New(models.StepTypeFreeNetworkAddresses, []string{param})
+		action, err := New(&config.AgentConfig{}, models.StepTypeFreeNetworkAddresses, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 
 		args := action.Args()
@@ -35,7 +36,7 @@ var _ = Describe("free addresses", func() {
 
 		By("Bad model object")
 		param = "[\"192.168.127.0/24\",\"rm -f\"]"
-		_, err := New(models.StepTypeFreeNetworkAddresses, []string{param})
+		_, err := New(&config.AgentConfig{}, models.StepTypeFreeNetworkAddresses, []string{param})
 		Expect(err).To(HaveOccurred())
 
 	})

--- a/src/commands/actions/image_availability_cmd.go
+++ b/src/commands/actions/image_availability_cmd.go
@@ -11,7 +11,8 @@ import (
 )
 
 type imageAvailability struct {
-	args []string
+	args        []string
+	agentConfig *config.AgentConfig
 }
 
 func (a *imageAvailability) Validate() error {
@@ -39,7 +40,7 @@ func (a *imageAvailability) Args() []string {
 		"--name", containerName,
 		"-v", "/var/log:/var/log",
 		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
-		config.GlobalAgentConfig.AgentVersion,
+		a.agentConfig.AgentVersion,
 		"container_image_availability",
 		"--request", a.args[0],
 	})

--- a/src/commands/actions/image_availability_cmd_test.go
+++ b/src/commands/actions/image_availability_cmd_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -19,7 +20,7 @@ var _ = Describe("image availability", func() {
 	})
 
 	It("image availability", func() {
-		action, err := New(models.StepTypeContainerImageAvailability, []string{param})
+		action, err := New(&config.AgentConfig{}, models.StepTypeContainerImageAvailability, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 
 		args := action.Args()

--- a/src/commands/actions/install_cmd.go
+++ b/src/commands/actions/install_cmd.go
@@ -36,6 +36,7 @@ type install struct {
 	args          []string
 	installParams models.InstallCmdRequest
 	filesystem    afero.Fs
+	agentConfig   *config.AgentConfig
 }
 
 func (a *install) Validate() error {
@@ -82,11 +83,6 @@ func (a *install) Validate() error {
 	return a.validateDisks()
 }
 
-func (a *install) CreateCmd() (string, []string) {
-	installCmd := a.getFullInstallerCommand()
-	return a.Command(), []string{"-c", installCmd}
-}
-
 func (a *install) getFullInstallerCommand() string {
 	podmanCmd := podmanBaseCmd[:]
 
@@ -96,10 +92,10 @@ func (a *install) getFullInstallerCommand() string {
 		"--cluster-id", a.installParams.ClusterID.String(),
 		"--host-id", string(*a.installParams.HostID),
 		"--boot-device", swag.StringValue(a.installParams.BootDevice),
-		"--url", config.GlobalAgentConfig.TargetURL,
+		"--url", a.agentConfig.TargetURL,
 		"--high-availability-mode", swag.StringValue(a.installParams.HighAvailabilityMode),
 		"--controller-image", swag.StringValue(a.installParams.ControllerImage),
-		"--agent-image", config.GlobalAgentConfig.AgentVersion,
+		"--agent-image", a.agentConfig.AgentVersion,
 	}
 
 	if a.installParams.McoImage != "" {
@@ -124,7 +120,7 @@ func (a *install) getFullInstallerCommand() string {
 		format <boolean flag> <value> is not supported by golang flag package and will cause the flags processing to finish
 		before processing the rest of the input flags
 	*/
-	if config.GlobalAgentConfig.InsecureConnection {
+	if a.agentConfig.InsecureConnection {
 		installerCmdArgs = append(installerCmdArgs, "--insecure")
 	}
 
@@ -132,10 +128,10 @@ func (a *install) getFullInstallerCommand() string {
 		installerCmdArgs = append(installerCmdArgs, "--check-cluster-version")
 	}
 
-	if config.GlobalAgentConfig.CACertificatePath != "" {
-		podmanCmd = append(podmanCmd, "-v", fmt.Sprintf("%s:%s:rw", config.GlobalAgentConfig.CACertificatePath,
-			config.GlobalAgentConfig.CACertificatePath))
-		installerCmdArgs = append(installerCmdArgs, "--cacert", config.GlobalAgentConfig.CACertificatePath)
+	if a.agentConfig.CACertificatePath != "" {
+		podmanCmd = append(podmanCmd, "-v", fmt.Sprintf("%s:%s:rw", a.agentConfig.CACertificatePath,
+			a.agentConfig.CACertificatePath))
+		installerCmdArgs = append(installerCmdArgs, "--cacert", a.agentConfig.CACertificatePath)
 	}
 
 	if a.installParams.InstallerArgs != "" {

--- a/src/commands/actions/inventory_cmd.go
+++ b/src/commands/actions/inventory_cmd.go
@@ -11,7 +11,8 @@ import (
 )
 
 type inventory struct {
-	args []string
+	args        []string
+	agentConfig *config.AgentConfig
 }
 
 func (a *inventory) Validate() error {
@@ -62,7 +63,7 @@ func (a *inventory) Args() []string {
 		"-v", "/run/udev:/host/run/udev:ro",
 		"-v", "/dev/disk:/host/dev/disk:ro",
 
-		config.GlobalAgentConfig.AgentVersion,
+		a.agentConfig.AgentVersion,
 		"inventory",
 	}, " ")
 

--- a/src/commands/actions/inventory_cmd_test.go
+++ b/src/commands/actions/inventory_cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -25,7 +26,7 @@ var _ = Describe("inventory", func() {
 
 	It("inventory cmd", func() {
 
-		action, err := New(models.StepTypeInventory, []string{hostId.String()})
+		action, err := New(&config.AgentConfig{}, models.StepTypeInventory, []string{hostId.String()})
 		Expect(err).NotTo(HaveOccurred())
 
 		args := action.Args()

--- a/src/commands/actions/logs_gather_test.go
+++ b/src/commands/actions/logs_gather_test.go
@@ -13,17 +13,19 @@ import (
 var _ = Describe("Logs gather test", func() {
 	var param string
 	var oldConfig config.ConnectivityConfig
+	var agentConfig *config.AgentConfig
 
 	BeforeEach(func() {
 		param = "{\"bootstrap\":true,\"cluster_id\":\"57a0830c-0d5f-45ad-8513-7d0060c33615\"," +
 			"\"host_id\":\"9f45b240-73d5-4390-a04e-7f5a09da44f7\",\"infra_env_id\":\"ea123507-1875-4da2-968a-15bb2d4b1e91\"," +
 			"\"installer_gather\":true,\"master_ips\":[\"192.168.127.10\",\"192.168.127.12\"]}"
+		agentConfig = &config.AgentConfig{}
 	})
 
 	It("Logs gather bootstrap", func() {
-		Expect(copier.Copy(&oldConfig, &config.GlobalAgentConfig.ConnectivityConfig)).To(BeNil())
-		config.GlobalAgentConfig.InsecureConnection = true
-		action, err := New(models.StepTypeLogsGather, []string{param})
+		Expect(copier.Copy(&oldConfig, &agentConfig.ConnectivityConfig)).To(BeNil())
+		agentConfig.InsecureConnection = true
+		action, err := New(agentConfig, models.StepTypeLogsGather, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 
 		args := action.Args()
@@ -41,7 +43,7 @@ var _ = Describe("Logs gather test", func() {
 		Expect(strings.Join(args, " ")).To(ContainSubstring("-bootstrap=true -with-installer-gather-logging=true"))
 	})
 	AfterEach(func() {
-		Expect(copier.Copy(&config.GlobalAgentConfig.ConnectivityConfig, &oldConfig)).To(BeNil())
+		Expect(copier.Copy(&agentConfig.ConnectivityConfig, &oldConfig)).To(BeNil())
 	})
 
 	It("Logs gather ca cert", func() {
@@ -49,8 +51,8 @@ var _ = Describe("Logs gather test", func() {
 			"\"host_id\":\"9f45b240-73d5-4390-a04e-7f5a09da44f7\",\"infra_env_id\":\"ea123507-1875-4da2-968a-15bb2d4b1e91\"," +
 			"\"installer_gather\":true,\"master_ips\":[\"192.168.127.10\",\"192.168.127.12\"]}"
 
-		config.GlobalAgentConfig.CACertificatePath = "/ca_cert"
-		action, err := New(models.StepTypeLogsGather, []string{param})
+		agentConfig.CACertificatePath = "/ca_cert"
+		action, err := New(agentConfig, models.StepTypeLogsGather, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 
 		args := action.Args()
@@ -74,21 +76,21 @@ var _ = Describe("Logs gather test", func() {
 		param = "{\"bootstrap\":true,\"cluster_id\":\"bad\"," +
 			"\"host_id\":\"9f45b240-73d5-4390-a04e-7f5a09da44f7\",\"infra_env_id\":\"ea123507-1875-4da2-968a-15bb2d4b1e91\"," +
 			"\"installer_gather\":true,\"master_ips\":[\"192.168.127.10\",\"192.168.127.12\"]}"
-		_, err := New(models.StepTypeLogsGather, []string{param})
+		_, err := New(agentConfig, models.StepTypeLogsGather, []string{param})
 		Expect(err).To(HaveOccurred())
 
 		By("Bad Ip")
 		param = "{\"bootstrap\":true,\"cluster_id\":\"57a0830c-0d5f-45ad-8513-7d0060c33615\"," +
 			"\"host_id\":\"9f45b240-73d5-4390-a04e-7f5a09da44f7\",\"infra_env_id\":\"ea123507-1875-4da2-968a-15bb2d4b1e91\"," +
 			"\"installer_gather\":true,\"master_ips\":[\"192.168.127.10\",\"echo\"]}"
-		_, err = New(models.StepTypeLogsGather, []string{param})
+		_, err = New(agentConfig, models.StepTypeLogsGather, []string{param})
 		Expect(err).To(HaveOccurred())
 
 		By("Bad boolean")
 		param = "{\"bootstrap\":\"echo\",\"cluster_id\":\"57a0830c-0d5f-45ad-8513-7d0060c33615\"," +
 			"\"host_id\":\"9f45b240-73d5-4390-a04e-7f5a09da44f7\",\"infra_env_id\":\"ea123507-1875-4da2-968a-15bb2d4b1e91\"," +
 			"\"installer_gather\":true,\"master_ips\":[\"192.168.127.10\"]}"
-		_, err = New(models.StepTypeLogsGather, []string{param})
+		_, err = New(agentConfig, models.StepTypeLogsGather, []string{param})
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/src/commands/actions/next_step_runner.go
+++ b/src/commands/actions/next_step_runner.go
@@ -15,10 +15,11 @@ import (
 type nextStepRunnerAction struct {
 	args                 []string
 	nextStepRunnerParams models.NextStepCmdRequest
+	agentConfig          *config.AgentConfig
 }
 
-func NewNextStepRunnerAction(args []string) ActionInterface {
-	return &nextStepRunnerAction{args: args}
+func NewNextStepRunnerAction(agentConfig *config.AgentConfig, args []string) ActionInterface {
+	return &nextStepRunnerAction{args: args, agentConfig: agentConfig}
 }
 
 func (a *nextStepRunnerAction) Validate() error {
@@ -27,39 +28,6 @@ func (a *nextStepRunnerAction) Validate() error {
 		return err
 	}
 	return nil
-}
-
-func (a *nextStepRunnerAction) CreateCmd() (string, []string) {
-	arguments := []string{"run", "--rm", "-ti", "--privileged", "--pid=host", "--net=host",
-		"-v", "/dev:/dev:rw", "-v", "/opt:/opt:rw",
-		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
-		"-v", "/var/log:/var/log:rw",
-		"-v", "/run/media:/run/media:rw",
-		"-v", "/etc/pki:/etc/pki"}
-
-	if config.GlobalAgentConfig.CACertificatePath != "" {
-		arguments = append(arguments, "-v", fmt.Sprintf("%s:%s", config.GlobalAgentConfig.CACertificatePath,
-			config.GlobalAgentConfig.CACertificatePath))
-	}
-
-	arguments = append(arguments,
-		"--env", "PULL_SECRET_TOKEN",
-		"--env", "CONTAINERS_CONF",
-		"--env", "CONTAINERS_STORAGE_CONF",
-		"--env", "HTTP_PROXY", "--env", "HTTPS_PROXY", "--env", "NO_PROXY",
-		"--env", "http_proxy", "--env", "https_proxy", "--env", "no_proxy",
-		"--name", "next-step-runner", swag.StringValue(a.nextStepRunnerParams.AgentVersion), "next_step_runner",
-		"--url", config.GlobalAgentConfig.TargetURL,
-		"--infra-env-id", a.nextStepRunnerParams.InfraEnvID.String(),
-		"--host-id", a.nextStepRunnerParams.HostID.String(),
-		"--agent-version", swag.StringValue(a.nextStepRunnerParams.AgentVersion),
-		fmt.Sprintf("--insecure=%s", strconv.FormatBool(config.GlobalAgentConfig.InsecureConnection)))
-
-	if config.GlobalAgentConfig.CACertificatePath != "" {
-		arguments = append(arguments, "--cacert", config.GlobalAgentConfig.CACertificatePath)
-	}
-
-	return a.Command(), arguments
 }
 
 func (a *nextStepRunnerAction) Run() (stdout, stderr string, exitCode int) {
@@ -78,9 +46,9 @@ func (a *nextStepRunnerAction) Args() []string {
 		"-v", "/run/media:/run/media:rw",
 		"-v", "/etc/pki:/etc/pki"}
 
-	if config.GlobalAgentConfig.CACertificatePath != "" {
-		arguments = append(arguments, "-v", fmt.Sprintf("%s:%s", config.GlobalAgentConfig.CACertificatePath,
-			config.GlobalAgentConfig.CACertificatePath))
+	if a.agentConfig.CACertificatePath != "" {
+		arguments = append(arguments, "-v", fmt.Sprintf("%s:%s", a.agentConfig.CACertificatePath,
+			a.agentConfig.CACertificatePath))
 	}
 
 	arguments = append(arguments,
@@ -90,14 +58,14 @@ func (a *nextStepRunnerAction) Args() []string {
 		"--env", "HTTP_PROXY", "--env", "HTTPS_PROXY", "--env", "NO_PROXY",
 		"--env", "http_proxy", "--env", "https_proxy", "--env", "no_proxy",
 		"--name", "next-step-runner", swag.StringValue(a.nextStepRunnerParams.AgentVersion), "next_step_runner",
-		"--url", config.GlobalAgentConfig.TargetURL,
+		"--url", a.agentConfig.TargetURL,
 		"--infra-env-id", a.nextStepRunnerParams.InfraEnvID.String(),
 		"--host-id", a.nextStepRunnerParams.HostID.String(),
 		"--agent-version", swag.StringValue(a.nextStepRunnerParams.AgentVersion),
-		fmt.Sprintf("--insecure=%s", strconv.FormatBool(config.GlobalAgentConfig.InsecureConnection)))
+		fmt.Sprintf("--insecure=%s", strconv.FormatBool(a.agentConfig.InsecureConnection)))
 
-	if config.GlobalAgentConfig.CACertificatePath != "" {
-		arguments = append(arguments, "--cacert", config.GlobalAgentConfig.CACertificatePath)
+	if a.agentConfig.CACertificatePath != "" {
+		arguments = append(arguments, "--cacert", a.agentConfig.CACertificatePath)
 	}
 
 	return arguments

--- a/src/commands/actions/ntp_sync_cmd.go
+++ b/src/commands/actions/ntp_sync_cmd.go
@@ -10,7 +10,8 @@ import (
 )
 
 type ntpSynchronizer struct {
-	args []string
+	args        []string
+	agentConfig *config.AgentConfig
 }
 
 func (a *ntpSynchronizer) Validate() error {
@@ -44,7 +45,7 @@ func (a *ntpSynchronizer) Args() []string {
 		"-v", "/var/log:/var/log",
 		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
 		"-v", "/var/run/chrony:/var/run/chrony",
-		config.GlobalAgentConfig.AgentVersion,
+		a.agentConfig.AgentVersion,
 		"ntp_synchronizer",
 	}
 	podmanRunCmd = append(podmanRunCmd, a.args...)

--- a/src/commands/actions/ntp_sync_cmd_test.go
+++ b/src/commands/actions/ntp_sync_cmd_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -16,7 +17,7 @@ var _ = Describe("ntp sync", func() {
 	})
 
 	It("ntp sync", func() {
-		action, err := New(models.StepTypeNtpSynchronizer, []string{param})
+		action, err := New(&config.AgentConfig{}, models.StepTypeNtpSynchronizer, []string{param})
 		Expect(err).NotTo(HaveOccurred())
 
 		args := action.Args()
@@ -39,7 +40,7 @@ var _ = Describe("ntp sync", func() {
 
 	It("bad ntp sync ntp source", func() {
 		param = "{\"ntp_source\":\"echo aaa\"}"
-		_, err := New(models.StepTypeNtpSynchronizer, []string{param})
+		_, err := New(&config.AgentConfig{}, models.StepTypeNtpSynchronizer, []string{param})
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/src/commands/actions/stop_installation_test.go
+++ b/src/commands/actions/stop_installation_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -13,7 +14,7 @@ var _ = Describe("stop", func() {
 	})
 
 	It("stop", func() {
-		action, err := New(models.StepTypeStopInstallation, []string{})
+		action, err := New(&config.AgentConfig{}, models.StepTypeStopInstallation, []string{})
 		Expect(err).NotTo(HaveOccurred())
 
 		args := action.Args()

--- a/src/commands/runner.go
+++ b/src/commands/runner.go
@@ -2,16 +2,17 @@ package commands
 
 import (
 	"github.com/openshift/assisted-installer-agent/src/commands/actions"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-installer-agent/src/util"
 	"github.com/openshift/assisted-service/models"
 )
 
 type NextStepRunnerFactory interface {
-	Create(command string, args []string) (Runner, error)
+	Create(agentConfig *config.AgentConfig, command string, args []string) (Runner, error)
 }
 
 type ToolRunnerFactory interface {
-	Create(stepType models.StepType, command string, args []string) (Runner, error)
+	Create(agentConfig *config.AgentConfig, stepType models.StepType, command string, args []string) (Runner, error)
 }
 
 // Runner is the means to allow pluggable running mechanism to agent.
@@ -29,10 +30,10 @@ func NewToolRunnerFactory() ToolRunnerFactory {
 	return &toolRunnerFactory{}
 }
 
-func (a *toolRunnerFactory) Create(stepType models.StepType, command string, args []string) (Runner, error) {
+func (a *toolRunnerFactory) Create(agentConfig *config.AgentConfig, stepType models.StepType, command string, args []string) (Runner, error) {
 	// TODO: MGMT-9451 remove command == "" after agent changes for new protocol will be pushed, added to allow pushing agent before service
 	if command == "" {
-		actionToRun, err := actions.New(stepType, args)
+		actionToRun, err := actions.New(agentConfig, stepType, args)
 		if err != nil {
 			return nil, err
 		}

--- a/src/config/agent_config.go
+++ b/src/config/agent_config.go
@@ -10,7 +10,8 @@ import (
 
 const agentVersionTagDelimiter = ":"
 
-var GlobalAgentConfig struct {
+type AgentConfig struct {
+	DryRunConfig
 	ConnectivityConfig
 	IntervalSecs int
 	HostID       string
@@ -22,8 +23,8 @@ func printHelpAndExit() {
 	os.Exit(0)
 }
 
-func ProcessArgs() {
-	ret := &GlobalAgentConfig
+func ProcessArgs() *AgentConfig {
+	ret := &AgentConfig{}
 	flag.StringVar(&ret.TargetURL, "url", "", "The target URL, including a scheme and optionally a port (overrides the host and port arguments")
 	flag.StringVar(&ret.InfraEnvID, "infra-env-id", "", "The value of infra-env-id")
 	flag.StringVar(&ret.AgentVersion, "agent-version", "", "Discovery agent version")
@@ -57,4 +58,5 @@ func ProcessArgs() {
 	// Otherwise, we leave the agent-version str intact.
 	agentVersionTag := strings.Split(ret.AgentVersion, agentVersionTagDelimiter)
 	ret.DiscoveryAgentVersion = agentVersionTag[len(agentVersionTag)-1]
+	return ret
 }

--- a/src/config/dry_run_config.go
+++ b/src/config/dry_run_config.go
@@ -18,9 +18,7 @@ type DryRunConfig struct {
 	FakeRebootMarkerPath string `envconfig:"DRY_FAKE_REBOOT_MARKER_PATH"`
 }
 
-var GlobalDryRunConfig DryRunConfig
-
-var DefaultDryRunConfig DryRunConfig = DryRunConfig{
+var DefaultDryRunConfig = DryRunConfig{
 	DryRunEnabled:        false,
 	ForcedHostID:         "",
 	ForcedHostIPv4:       "",
@@ -29,18 +27,18 @@ var DefaultDryRunConfig DryRunConfig = DryRunConfig{
 	FakeRebootMarkerPath: "",
 }
 
-func ProcessDryRunArgs() {
+func ProcessDryRunArgs(dryRunConfig *DryRunConfig) {
 	err := envconfig.Process("dryconfig", &DefaultDryRunConfig)
 	if err != nil {
 		fmt.Printf("envconfig error: %v", err)
 		os.Exit(1)
 	}
 
-	flag.BoolVar(&GlobalDryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
-	flag.StringVar(&GlobalDryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
-	flag.StringVar(&GlobalDryRunConfig.ForcedMacAddress, "force-mac", DefaultDryRunConfig.ForcedMacAddress, "The fake mac address to give to the first network interface")
-	flag.StringVar(&GlobalDryRunConfig.ForcedHostname, "force-hostname", DefaultDryRunConfig.ForcedHostname, "The fake hostname to give to this host")
-	flag.StringVar(&GlobalDryRunConfig.ForcedHostIPv4, "forced-ipv4", DefaultDryRunConfig.ForcedHostIPv4, "The fake ip address to give to the host's network interface")
-	flag.StringVar(&GlobalDryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
+	flag.BoolVar(&dryRunConfig.DryRunEnabled, "dry-run", DefaultDryRunConfig.DryRunEnabled, "Dry run avoids/fakes certain actions while communicating with the service")
+	flag.StringVar(&dryRunConfig.ForcedHostID, "force-id", DefaultDryRunConfig.ForcedHostID, "The fake host ID to give to the host")
+	flag.StringVar(&dryRunConfig.ForcedMacAddress, "force-mac", DefaultDryRunConfig.ForcedMacAddress, "The fake mac address to give to the first network interface")
+	flag.StringVar(&dryRunConfig.ForcedHostname, "force-hostname", DefaultDryRunConfig.ForcedHostname, "The fake hostname to give to this host")
+	flag.StringVar(&dryRunConfig.ForcedHostIPv4, "forced-ipv4", DefaultDryRunConfig.ForcedHostIPv4, "The fake ip address to give to the host's network interface")
+	flag.StringVar(&dryRunConfig.FakeRebootMarkerPath, "fake-reboot-marker-path", DefaultDryRunConfig.FakeRebootMarkerPath, "A path whose existence indicates a fake reboot happened")
 	flag.Parse()
 }

--- a/src/config/logs_sender_config.go
+++ b/src/config/logs_sender_config.go
@@ -6,9 +6,9 @@ import (
 	"os"
 )
 
-var LogsSenderConfig struct {
-	TextLogging            bool
-	JournalLogging         bool
+type LogsSenderConfig struct {
+	LoggingConfig
+	AgentConfig
 	Tags                   []string
 	Services               []string
 	Since                  string
@@ -23,27 +23,28 @@ var LogsSenderConfig struct {
 	MastersIPs             string
 }
 
-func ProcessLogsSenderConfigArgs(defaultTextLogging, defaultJournalLogging bool) {
+func ProcessLogsSenderConfigArgs(defaultTextLogging, defaultJournalLogging bool) *LogsSenderConfig {
 	var leaveFiles bool
-	flag.BoolVar(&LogsSenderConfig.JournalLogging, "with-journal-logging", defaultJournalLogging, "Use journal logging")
-	flag.BoolVar(&LogsSenderConfig.TextLogging, "with-text-logging", defaultTextLogging, "Use text logging")
-	flag.StringVar(&LogsSenderConfig.Since, "since", "5 hours ago", "Journalctl since flag, same format")
-	flag.StringVar(&LogsSenderConfig.TargetURL, "url", "", "The target URL, including a scheme and optionally a port (overrides the host and port arguments")
-	flag.StringVar(&LogsSenderConfig.ClusterID, "cluster-id", "", "The value of the cluster-id, required")
-	flag.StringVar(&LogsSenderConfig.InfraEnvID, "infra-env-id", "", "The value of the infra-env-id")
-	flag.StringVar(&LogsSenderConfig.HostID, "host-id", "host-id", "The value of the host-id")
-	flag.StringVar(&LogsSenderConfig.PullSecretToken, "pull-secret-token", "", "Pull secret token")
+	loggingConfig := &LogsSenderConfig{}
+	flag.BoolVar(&loggingConfig.JournalLogging, "with-journal-logging", defaultJournalLogging, "Use journal logging")
+	flag.BoolVar(&loggingConfig.TextLogging, "with-text-logging", defaultTextLogging, "Use text logging")
+	flag.StringVar(&loggingConfig.Since, "since", "5 hours ago", "Journalctl since flag, same format")
+	flag.StringVar(&loggingConfig.TargetURL, "url", "", "The target URL, including a scheme and optionally a port (overrides the host and port arguments")
+	flag.StringVar(&loggingConfig.ClusterID, "cluster-id", "", "The value of the cluster-id, required")
+	flag.StringVar(&loggingConfig.InfraEnvID, "infra-env-id", "", "The value of the infra-env-id")
+	flag.StringVar(&loggingConfig.HostID, "host-id", "host-id", "The value of the host-id")
+	flag.StringVar(&loggingConfig.PullSecretToken, "pull-secret-token", "", "Pull secret token")
 	flag.BoolVar(&leaveFiles, "dont-clean", false, "Don't delete all created files on finish. Required")
-	flag.BoolVar(&LogsSenderConfig.IsBootstrap, "bootstrap", false, "Gather and send logs on bootstrap node")
-	flag.BoolVar(&LogsSenderConfig.InstallerGatherlogging, "with-installer-gather-logging", false, "Use installer-gather logging")
-	flag.StringVar(&GlobalAgentConfig.CACertificatePath, "cacert", "", "Path to custom CA certificate in PEM format")
-	flag.BoolVar(&GlobalAgentConfig.InsecureConnection, "insecure", false, "Do not validate TLS certificate")
-	flag.StringVar(&LogsSenderConfig.MastersIPs, "masters-ips", "", "list of ',' separated IPs of all masters nodes in the cluster for SSH use")
+	flag.BoolVar(&loggingConfig.IsBootstrap, "bootstrap", false, "Gather and send logs on bootstrap node")
+	flag.BoolVar(&loggingConfig.InstallerGatherlogging, "with-installer-gather-logging", false, "Use installer-gather logging")
+	flag.StringVar(&loggingConfig.CACertificatePath, "cacert", "", "Path to custom CA certificate in PEM format")
+	flag.BoolVar(&loggingConfig.InsecureConnection, "insecure", false, "Do not validate TLS certificate")
+	flag.StringVar(&loggingConfig.MastersIPs, "masters-ips", "", "list of ',' separated IPs of all masters nodes in the cluster for SSH use")
 	h := flag.Bool("help", false, "Help message")
 
 	flag.Parse()
 
-	LogsSenderConfig.CleanWhenDone = !leaveFiles
+	loggingConfig.CleanWhenDone = !leaveFiles
 
 	if h != nil && *h {
 		printHelpAndExit()
@@ -59,12 +60,13 @@ func ProcessLogsSenderConfigArgs(defaultTextLogging, defaultJournalLogging bool)
 		}
 	}
 
-	LogsSenderConfig.Tags = []string{"agent", "installer"}
-	if LogsSenderConfig.IsBootstrap {
-		LogsSenderConfig.Services = []string{"bootkube"}
+	loggingConfig.Tags = []string{"agent", "installer"}
+	if loggingConfig.IsBootstrap {
+		loggingConfig.Services = []string{"bootkube"}
 	}
 
-	if LogsSenderConfig.PullSecretToken == "" {
-		LogsSenderConfig.PullSecretToken = os.Getenv("PULL_SECRET_TOKEN")
+	if loggingConfig.PullSecretToken == "" {
+		loggingConfig.PullSecretToken = os.Getenv("PULL_SECRET_TOKEN")
 	}
+	return loggingConfig
 }

--- a/src/config/subprocess_config.go
+++ b/src/config/subprocess_config.go
@@ -9,21 +9,26 @@ type LoggingConfig struct {
 }
 
 // SubprocessConfig processe's logging configuration
-var SubprocessConfig LoggingConfig
+type SubprocessConfig struct {
+	LoggingConfig
+	DryRunConfig
+}
 
 // DefaultLoggingConfig pre-defined most commonly used defaults
-var DefaultLoggingConfig LoggingConfig = LoggingConfig{
+var DefaultLoggingConfig = LoggingConfig{
 	TextLogging:    false,
 	JournalLogging: true,
 }
 
 // ProcessSubprocessArgs parses arguments
-func ProcessSubprocessArgs(loggingDefaults LoggingConfig) {
-	flag.BoolVar(&SubprocessConfig.JournalLogging, "with-journal-logging", loggingDefaults.JournalLogging, "Use journal logging")
-	flag.BoolVar(&SubprocessConfig.TextLogging, "with-text-logging", loggingDefaults.TextLogging, "Use text logging")
+func ProcessSubprocessArgs(loggingDefaults LoggingConfig) *SubprocessConfig {
+	subprocessConfig := &SubprocessConfig{}
+	flag.BoolVar(&subprocessConfig.JournalLogging, "with-journal-logging", loggingDefaults.JournalLogging, "Use journal logging")
+	flag.BoolVar(&subprocessConfig.TextLogging, "with-text-logging", loggingDefaults.TextLogging, "Use text logging")
 	h := flag.Bool("help", false, "Help message")
 	flag.Parse()
 	if h != nil && *h {
 		printHelpAndExit()
 	}
+	return subprocessConfig
 }

--- a/src/connectivity_check/connectivity_check_test.go
+++ b/src/connectivity_check/connectivity_check_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/openshift/assisted-service/models"
@@ -263,7 +264,7 @@ var _ = Describe("nmap analysis test", func() {
 		t := tests[i]
 		It(t.name, func() {
 			out := make(chan any)
-			go analyzeNmap(t.dstAddr, t.dstMAC, t.allDstMACs, "eth0", out, testNmap{t.output})
+			go analyzeNmap(t.dstAddr, t.dstMAC, t.allDstMACs, "eth0", out, testNmap{t.output}, false)
 			Expect(<-out).To(Equal(t.expected))
 		})
 	}
@@ -487,7 +488,8 @@ var _ = Describe("check host parallel validation", func() {
 		t := tests[i]
 		It(t.name, func() {
 			h := testHostChecker{outgoingNICS: t.nics, host: t.hosts, success: t.success}
-			go checkHost(h, hostChan)
+			c := connectivity{dryRunConfig: &config.DryRunConfig{}}
+			go c.checkHost(h, hostChan)
 			r := <-hostChan
 			Expect(r.L2Connectivity).Should(ContainElements(t.expected.L2Connectivity))
 			Expect(r.L3Connectivity).Should(ContainElements(t.expected.L3Connectivity))

--- a/src/connectivity_check/main/main.go
+++ b/src/connectivity_check/main/main.go
@@ -13,14 +13,14 @@ import (
 )
 
 func main() {
-	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
-	config.ProcessDryRunArgs()
-	util.SetLogging("connectivity-check", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
+	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
+	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
+	util.SetLogging("connectivity-check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Warnf("Expecting exactly single argument to connectivity check. Received %d", len(os.Args)-1)
 		os.Exit(-1)
 	}
-	stdout, stderr, exitCode := connectivity_check.ConnectivityCheck("", flag.Arg(0))
+	stdout, stderr, exitCode := connectivity_check.ConnectivityCheck(&subprocessConfig.DryRunConfig, "", flag.Arg(0))
 	fmt.Fprint(os.Stdout, stdout)
 	fmt.Fprint(os.Stderr, stderr)
 	os.Exit(exitCode)

--- a/src/container_image_availability/container_image_availability.go
+++ b/src/container_image_availability/container_image_availability.go
@@ -99,8 +99,8 @@ func pullImage(executer ImageAvailabilityDependencies, pullTimeoutSeconds int64,
 	}
 }
 
-func handleImageAvailability(executer ImageAvailabilityDependencies, log logrus.FieldLogger, pullTimeoutSeconds int64, image string) *models.ContainerImageAvailability {
-	if config.GlobalDryRunConfig.DryRunEnabled {
+func handleImageAvailability(subprocessConfig *config.SubprocessConfig, executer ImageAvailabilityDependencies, log logrus.FieldLogger, pullTimeoutSeconds int64, image string) *models.ContainerImageAvailability {
+	if subprocessConfig.DryRunEnabled {
 		log.Infof("Running in dry mode - skipping image availability test, returning fake results")
 		return getDryModeContainerImageAvailability(image)
 	}
@@ -146,7 +146,7 @@ func handleImageAvailability(executer ImageAvailabilityDependencies, log logrus.
 	return response
 }
 
-func Run(requestStr string, executer ImageAvailabilityDependencies, log logrus.FieldLogger) (stdout string, stderr string, exitCode int) {
+func Run(subprocessConfig *config.SubprocessConfig, requestStr string, executer ImageAvailabilityDependencies, log logrus.FieldLogger) (stdout string, stderr string, exitCode int) {
 	exitCode = 0
 	var request models.ContainerImageAvailabilityRequest
 	var response models.ContainerImageAvailabilityResponse
@@ -159,7 +159,7 @@ func Run(requestStr string, executer ImageAvailabilityDependencies, log logrus.F
 
 	finishOnTimeout := time.Now().Add(time.Duration(request.Timeout) * time.Second)
 	for _, image := range request.Images {
-		imageResponse := handleImageAvailability(executer, log, int64(time.Until(finishOnTimeout).Seconds()), image)
+		imageResponse := handleImageAvailability(subprocessConfig, executer, log, int64(time.Until(finishOnTimeout).Seconds()), image)
 		response.Images = append(response.Images, imageResponse)
 		if imageResponse.Result != models.ContainerImageAvailabilityResultSuccess {
 			exitCode = failedToPullImageExitCode

--- a/src/container_image_availability/main/main.go
+++ b/src/container_image_availability/main/main.go
@@ -31,11 +31,11 @@ func processArgs() {
 
 func main() {
 	processArgs()
-	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
-	config.ProcessDryRunArgs()
-	util.SetLogging("container_image_availability", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
+	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
+	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
+	util.SetLogging("container_image_availability", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
 	log.StandardLogger().Infof("Checking image availability, requested images: %s", executableConfig.Request)
-	stdout, stderr, exitCode := container_image_availability.Run(executableConfig.Request,
+	stdout, stderr, exitCode := container_image_availability.Run(subprocessConfig, executableConfig.Request,
 		&container_image_availability.ProcessExecuter{}, log.StandardLogger())
 	fmt.Fprint(os.Stdout, stdout)
 	fmt.Fprint(os.Stderr, stderr)

--- a/src/dhcp_lease_allocate/main/main.go
+++ b/src/dhcp_lease_allocate/main/main.go
@@ -12,9 +12,9 @@ import (
 )
 
 func main() {
-	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
-	config.ProcessDryRunArgs()
-	util.SetLogging("dhcp_lease_allocate", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
+	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
+	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
+	util.SetLogging("dhcp_lease_allocate", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Warnf("Expecting exactly single argument to dhcp_lease_allocate. Received %d", len(os.Args)-1)
 		os.Exit(-1)

--- a/src/disk_speed_check/disk_speed_check.go
+++ b/src/disk_speed_check/disk_speed_check.go
@@ -15,11 +15,12 @@ const (
 )
 
 type DiskSpeedCheck struct {
-	dependecies IDependencies
+	dependecies      IDependencies
+	subprocessConfig *config.SubprocessConfig
 }
 
-func NewDiskSpeedCheck(dependencies IDependencies) *DiskSpeedCheck {
-	return &DiskSpeedCheck{dependecies: dependencies}
+func NewDiskSpeedCheck(subprocessConfig *config.SubprocessConfig, dependencies IDependencies) *DiskSpeedCheck {
+	return &DiskSpeedCheck{dependecies: dependencies, subprocessConfig: subprocessConfig}
 }
 
 func (p *DiskSpeedCheck) FioPerfCheck(diskSpeedCheckRequestStr string, log logrus.FieldLogger) (stdout string, stderr string, exitCode int) {
@@ -56,7 +57,7 @@ func (p *DiskSpeedCheck) getDiskPerf(path string) (int64, error) {
 		return -1, errors.New("Missing disk path")
 	}
 
-	if config.GlobalDryRunConfig.DryRunEnabled {
+	if p.subprocessConfig.DryRunEnabled {
 		// Don't want to cause the disk any harm in dry mode, so just pretend it's fast
 		return time.Duration(dryModeSyncDurationInNS).Milliseconds(), nil
 	}

--- a/src/disk_speed_check/disk_speed_check_test.go
+++ b/src/disk_speed_check/disk_speed_check_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
@@ -19,10 +20,12 @@ var _ = Describe("Disk speed check test", func() {
 	var dependencies *MockIDependencies
 	var perfCheck *DiskSpeedCheck
 	var log logrus.FieldLogger
+	var subprocessConfig *config.SubprocessConfig
 
 	BeforeEach(func() {
+		subprocessConfig = &config.SubprocessConfig{}
 		dependencies = &MockIDependencies{}
-		perfCheck = NewDiskSpeedCheck(dependencies)
+		perfCheck = NewDiskSpeedCheck(subprocessConfig, dependencies)
 		log = logrus.New()
 	})
 

--- a/src/disk_speed_check/main/main.go
+++ b/src/disk_speed_check/main/main.go
@@ -12,12 +12,12 @@ import (
 )
 
 func main() {
-	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
-	config.ProcessDryRunArgs()
-	util.SetLogging("disk-speed-check", config.GlobalAgentConfig.TextLogging, config.GlobalAgentConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
+	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
+	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
+	util.SetLogging("disk-speed-check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
 
 	req := flag.Arg(flag.NArg() - 1)
-	perfCheck := disk_speed_check.NewDiskSpeedCheck(disk_speed_check.NewDependencies())
+	perfCheck := disk_speed_check.NewDiskSpeedCheck(subprocessConfig, disk_speed_check.NewDependencies())
 	stdout, stderr, exitCode := perfCheck.FioPerfCheck(req, log.StandardLogger())
 	fmt.Fprint(os.Stdout, stdout)
 	fmt.Fprint(os.Stderr, stderr)

--- a/src/free_addresses/main/main.go
+++ b/src/free_addresses/main/main.go
@@ -13,9 +13,9 @@ import (
 )
 
 func main() {
-	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
-	config.ProcessDryRunArgs()
-	util.SetLogging("free_addresses", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
+	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
+	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
+	util.SetLogging("free_addresses", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Warnf("Expecting exactly single argument to free_addresses. Received %d", len(os.Args)-1)
 		os.Exit(-1)

--- a/src/inventory/bmc.go
+++ b/src/inventory/bmc.go
@@ -14,11 +14,12 @@ import (
 const MaxIpmiChannel = 12
 
 type bmc struct {
-	dependicies util.IDependencies
+	dependicies      util.IDependencies
+	subprocessConfig *config.SubprocessConfig
 }
 
-func newBMC(dependencies util.IDependencies) *bmc {
-	return &bmc{dependicies: dependencies}
+func newBMC(subprocessConfig *config.SubprocessConfig, dependencies util.IDependencies) *bmc {
+	return &bmc{dependicies: dependencies, subprocessConfig: subprocessConfig}
 }
 
 func (b *bmc) getIpForChannnel(ch int) string {
@@ -41,7 +42,7 @@ func (b *bmc) getIsEnabled(value interface{}) bool {
 }
 
 func (b *bmc) getBmcAddress() string {
-	if config.GlobalDryRunConfig.DryRunEnabled {
+	if b.subprocessConfig.DryRunEnabled {
 		// This action is too slow and unnecessary, so skip it in dry run
 		return "0.0.0.0"
 	}
@@ -62,8 +63,8 @@ func (b *bmc) getBmcAddress() string {
 	return "0.0.0.0"
 }
 
-func GetBmcAddress(dependencies util.IDependencies) string {
-	return newBMC(dependencies).getBmcAddress()
+func GetBmcAddress(subprocessConfig *config.SubprocessConfig, dependencies util.IDependencies) string {
+	return newBMC(subprocessConfig, dependencies).getBmcAddress()
 }
 
 func (b *bmc) getV6Address(ch int, addressType string) string {
@@ -126,7 +127,7 @@ func (b *bmc) getAddrMode(ch int) string {
 }
 
 func (b *bmc) getBmcV6Address() string {
-	if config.GlobalDryRunConfig.DryRunEnabled {
+	if b.subprocessConfig.DryRunEnabled {
 		// This action is too slow and unnecessary, so skip it in dry run
 		return "::/0"
 	}
@@ -152,6 +153,6 @@ func (b *bmc) getBmcV6Address() string {
 	return "::/0"
 }
 
-func GetBmcV6Address(dependencies util.IDependencies) string {
-	return newBMC(dependencies).getBmcV6Address()
+func GetBmcV6Address(subprocessConfig *config.SubprocessConfig, dependencies util.IDependencies) string {
+	return newBMC(subprocessConfig, dependencies).getBmcV6Address()
 }

--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -22,11 +22,12 @@ const (
 )
 
 type disks struct {
-	dependencies util.IDependencies
+	dependencies     util.IDependencies
+	subprocessConfig *config.SubprocessConfig
 }
 
-func newDisks(dependencies util.IDependencies) *disks {
-	return &disks{dependencies: dependencies}
+func newDisks(subprocessConfig *config.SubprocessConfig, dependencies util.IDependencies) *disks {
+	return &disks{dependencies: dependencies, subprocessConfig: subprocessConfig}
 }
 
 func (d *disks) getDisksWWNs() map[string]string {
@@ -128,7 +129,7 @@ func (d *disks) getSMART(path string) string {
 		return ""
 	}
 
-	if config.GlobalDryRunConfig.DryRunEnabled {
+	if d.subprocessConfig.DryRunEnabled {
 		// smartctl is rather slow, better to avoid it dry run mode
 		return dryRunSmart
 	}
@@ -304,6 +305,6 @@ func (d *disks) getBusPath(disks []*block.Disk, index int, busPath string) strin
 	return d.getByPath(busPath)
 }
 
-func GetDisks(dependencies util.IDependencies) []*models.Disk {
-	return newDisks(dependencies).getDisks()
+func GetDisks(subprocessConfig *config.SubprocessConfig, dependencies util.IDependencies) []*models.Disk {
+	return newDisks(subprocessConfig, dependencies).getDisks()
 }

--- a/src/inventory/dry_inventory.go
+++ b/src/inventory/dry_inventory.go
@@ -7,15 +7,15 @@ import (
 	"github.com/openshift/assisted-service/models"
 )
 
-func applyDryRunConfig(inventory *models.Inventory) {
+func applyDryRunConfig(subprocessConfig *config.SubprocessConfig, inventory *models.Inventory) {
 	targetInterface, err := findRelevantInterface(inventory)
 	if err != nil {
 		return
 	}
 
 	// Override the mac address & IPv4 address to the user requested one
-	inventory.Interfaces[targetInterface].MacAddress = config.GlobalDryRunConfig.ForcedMacAddress
-	inventory.Interfaces[targetInterface].IPV4Addresses[0] = config.GlobalDryRunConfig.ForcedHostIPv4
+	inventory.Interfaces[targetInterface].MacAddress = subprocessConfig.ForcedMacAddress
+	inventory.Interfaces[targetInterface].IPV4Addresses[0] = subprocessConfig.ForcedHostIPv4
 
 	// Throw away other interfaces to avoid some exotic bugs relating to duplicate mac addreses from two different hosts
 	inventory.Interfaces = []*models.Interface{inventory.Interfaces[targetInterface]}

--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -9,14 +9,14 @@ import (
 	"github.com/openshift/assisted-service/models"
 )
 
-func ReadInventory(c *Options) *models.Inventory {
-	d := util.NewDependencies(c.GhwChrootRoot)
+func ReadInventory(subprocessConfig *config.SubprocessConfig, c *Options) *models.Inventory {
+	d := util.NewDependencies(&subprocessConfig.DryRunConfig, c.GhwChrootRoot)
 	ret := models.Inventory{
-		BmcAddress:   GetBmcAddress(d),
-		BmcV6address: GetBmcV6Address(d),
+		BmcAddress:   GetBmcAddress(subprocessConfig, d),
+		BmcV6address: GetBmcV6Address(subprocessConfig, d),
 		Boot:         GetBoot(d),
 		CPU:          GetCPU(d),
-		Disks:        GetDisks(d),
+		Disks:        GetDisks(subprocessConfig, d),
 		Gpus:         GetGPUs(d),
 		Hostname:     GetHostname(d),
 		Interfaces:   GetInterfaces(d),
@@ -29,11 +29,11 @@ func ReadInventory(c *Options) *models.Inventory {
 	return &ret
 }
 
-func CreateInventoryInfo() []byte {
-	in := ReadInventory(&Options{GhwChrootRoot: "/host"})
+func CreateInventoryInfo(subprocessConfig *config.SubprocessConfig) []byte {
+	in := ReadInventory(subprocessConfig, &Options{GhwChrootRoot: "/host"})
 
-	if config.GlobalDryRunConfig.DryRunEnabled {
-		applyDryRunConfig(in)
+	if subprocessConfig.DryRunEnabled {
+		applyDryRunConfig(subprocessConfig, in)
 	}
 
 	b, _ := json.Marshal(&in)

--- a/src/inventory/main/main.go
+++ b/src/inventory/main/main.go
@@ -9,8 +9,8 @@ import (
 )
 
 func main() {
-	config.ProcessDryRunArgs()
-	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
-	util.SetLogging("inventory", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
-	fmt.Print(string(inventory.CreateInventoryInfo()))
+	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
+	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
+	util.SetLogging("inventory", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	fmt.Print(string(inventory.CreateInventoryInfo(subprocessConfig)))
 }

--- a/src/logs_sender/main/main.go
+++ b/src/logs_sender/main/main.go
@@ -11,12 +11,12 @@ import (
 )
 
 func main() {
-	config.ProcessLogsSenderConfigArgs(true, true)
-	config.ProcessDryRunArgs()
-	util.SetLoggingWithStdOut("logs-sender", config.LogsSenderConfig.TextLogging, config.LogsSenderConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
-	err, report := logs_sender.SendLogs(logs_sender.NewLogsSenderExecuter(config.LogsSenderConfig.TargetURL,
-		config.LogsSenderConfig.PullSecretToken,
-		config.GlobalAgentConfig.AgentVersion))
+	loggingConfig := config.ProcessLogsSenderConfigArgs(true, true)
+	config.ProcessDryRunArgs(&loggingConfig.DryRunConfig)
+	util.SetLoggingWithStdOut("logs-sender", loggingConfig.TextLogging, loggingConfig.JournalLogging, loggingConfig.ForcedHostID)
+	err, report := logs_sender.SendLogs(loggingConfig, logs_sender.NewLogsSenderExecuter(loggingConfig, loggingConfig.TargetURL,
+		loggingConfig.PullSecretToken,
+		loggingConfig.AgentVersion))
 	if err != nil {
 		fmt.Println("Failed to run send logs ", err.Error())
 		os.Exit(-1)

--- a/src/ntp_synchronizer/main/main.go
+++ b/src/ntp_synchronizer/main/main.go
@@ -16,16 +16,16 @@ func DryRunNtp() (string, string, int) {
 }
 
 func main() {
-	config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
-	config.ProcessDryRunArgs()
-	util.SetLogging("ntp_synchronizer", config.SubprocessConfig.TextLogging, config.SubprocessConfig.JournalLogging, config.GlobalDryRunConfig.ForcedHostID)
+	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
+	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
+	util.SetLogging("ntp_synchronizer", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Fatalf("Expecting exactly single argument to ntp_synchronizer. Received %d", len(os.Args)-1)
 	}
 
 	// Skip NTP in dry run mode, it's too expensive
 	stdout, stderr, exitCode := DryRunNtp()
-	if !config.GlobalDryRunConfig.DryRunEnabled {
+	if !subprocessConfig.DryRunEnabled {
 		stdout, stderr, exitCode = ntp_synchronizer.Run(flag.Arg(0), &ntp_synchronizer.ProcessExecuter{}, log.StandardLogger())
 	}
 

--- a/src/util/dependencies.go
+++ b/src/util/dependencies.go
@@ -33,6 +33,7 @@ type IDependencies interface {
 type Dependencies struct {
 	NetlinkRouteFinder
 	GhwChrootRoot string
+	dryRunConfig  *config.DryRunConfig
 }
 
 func (d *Dependencies) GetGhwChrootRoot() string {
@@ -52,8 +53,8 @@ func (d *Dependencies) Stat(fname string) (os.FileInfo, error) {
 }
 
 func (d *Dependencies) Hostname() (string, error) {
-	if config.GlobalDryRunConfig.DryRunEnabled {
-		return config.GlobalDryRunConfig.ForcedHostname, nil
+	if d.dryRunConfig.DryRunEnabled {
+		return d.dryRunConfig.ForcedHostname, nil
 	}
 
 	return os.Hostname()
@@ -99,8 +100,9 @@ func (d *Dependencies) Memory(opts ...*ghw.WithOption) (*ghw.MemoryInfo, error) 
 	return ghw.Memory(opts...)
 }
 
-func NewDependencies(ghwChrootRoot string) IDependencies {
+func NewDependencies(dryRunConfig *config.DryRunConfig, ghwChrootRoot string) IDependencies {
 	return &Dependencies{
 		GhwChrootRoot: ghwChrootRoot,
+		dryRunConfig:  dryRunConfig,
 	}
 }

--- a/src/util/dry_reboot.go
+++ b/src/util/dry_reboot.go
@@ -2,10 +2,10 @@ package util
 
 import "github.com/openshift/assisted-installer-agent/src/config"
 
-func DryRebootHappened() bool {
+func DryRebootHappened(dryConfig *config.DryRunConfig) bool {
 	// The dry run installer creates this file on "Reboot" (instead of actually rebooting)
 	// We use this as a signal that we should terminate as well
-	if _, _, exitCode := ExecutePrivileged("stat", config.GlobalDryRunConfig.FakeRebootMarkerPath); exitCode == 0 {
+	if _, _, exitCode := ExecutePrivileged("stat", dryConfig.FakeRebootMarkerPath); exitCode == 0 {
 		return true
 	}
 


### PR DESCRIPTION
In order to launch multiple agents and multiple tools representing
different hosts in the same process for the swarm tool , use of global variables has to be
eliminated, and use function parameters instead.

/cc @omertuc 