### PR TITLE
AGENT-153: Add .ci-operator.yaml for OCP payload image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.17-openshift-4.11


### PR DESCRIPTION
We are looking to replicate the configuration that exists in `openshift/installer` for building images in the CI.

Adding `.ci-operator.yaml` so we can set the build root to be from the repository.

[AGENT-153](https://issues.redhat.com//browse/AGENT-153)

/cc @pawanpinjarkar @andfasano 