### PR TITLE
NO-ISSUE: remove redundant ok-to-test label 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
     labels:
       - "approved"
       - "lgtm"
-      - "ok-to-test"
       - "go"
       - "dependencies"
     commit-message:


### PR DESCRIPTION
We no longer need the ok-to-test label, as dependabot is a
trusted-app.

/cc @eliorerz @filanov 