### PR TITLE
MGMT-9505: SMART data should include only errors

### DIFF
--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -137,7 +137,7 @@ func (d *disks) getSMART(path string) string {
 	// We ignore the exit code and stderr because stderr is empty and
 	// stdout contains the exit code in `--json=c` mode. Whatever the exit
 	// code is, we want to relay the information to the service
-	stdout, _, _ := d.dependencies.Execute("smartctl", "--all", "--json=c", path)
+	stdout, _, _ := d.dependencies.Execute("smartctl", "--all", "--quiet=errorsonly", path)
 
 	return stdout
 }

--- a/src/inventory/disks_test.go
+++ b/src/inventory/disks_test.go
@@ -355,7 +355,7 @@ func mockGetBootable(dependencies *util.MockIDependencies, path string, bootable
 }
 
 func mockGetSMART(dependencies *util.MockIDependencies, path string, err string) *mock.Call {
-	return mockExecuteDependencyCall(dependencies, "smartctl", `{"some": "json"}`, err, "--all", "--json=c", path)
+	return mockExecuteDependencyCall(dependencies, "smartctl", `{"some": "json"}`, err, "--all", "--quiet=errorsonly", path)
 }
 
 func mockAllForSuccess(dependencies *util.MockIDependencies, disks ...*ghw.Disk) {
@@ -468,8 +468,8 @@ var _ = Describe("Disks test", func() {
 		})
 
 		It("With a smartctl error - make sure JSON is still transmitted", func() {
-			Expect(util.DeleteExpectedMethod(&dependencies.Mock, "Execute", "smartctl", "--all", "--json=c", "/dev/foo/disk1")).To(BeTrue())
-			dependencies.On("Execute", "smartctl", "--all", "--json=c", "/dev/foo/disk1").Return(`{"some": "json"}`, "", 1).Once()
+			Expect(util.DeleteExpectedMethod(&dependencies.Mock, "Execute", "smartctl", "--all", "--quiet=errorsonly", "/dev/foo/disk1")).To(BeTrue())
+			dependencies.On("Execute", "smartctl", "--all", "--quiet=errorsonly", "/dev/foo/disk1").Return(`{"some": "json"}`, "", 1).Once()
 			expectation[0].Smart = `{"some": "json"}`
 		})
 


### PR DESCRIPTION
Now the smart command runs "smartctl --all --quiet=errorsonly"
instead "smartctl --all --json=c"
JSON output was removed because it causes the option --quiet=errorsonly
to have no effect.
Currently the smart data is no in use anywhere, so it should not be a
problem.

/cc @avishayt 