### PR TITLE
ART-4057: Work around parsing issue on ART's tooling

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -21,7 +21,7 @@ COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/domain_resolution /usr/bin/domain_resolution
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/scripts/installer/* /usr/local/bin/
 
-RUN if [[ "$(arch)" == "x86_64" ]]; then dnf install -y biosdevname && dnf clean all; fi
+RUN test "$(arch)" -eq "x86_64" && { dnf install -y biosdevname && dnf clean all; } || true
 RUN dnf install -y dhclient dmidecode file findutils fio ipmitool iputils nmap openssh-clients podman chrony smartmontools && dnf clean all
 
 ENTRYPOINT ["/usr/bin/agent"]


### PR DESCRIPTION
ART's tooling makes use of [bashlex](https://github.com/idank/bashlex) to parse `RUN` commands found in Dockerfiles.
But for whatever reason it is failing to parse the following instruction:
```
RUN if [[ "$(arch)" == "x86_64" ]]; then dnf install -y biosdevname && dnf clean all; fi
```

```
bashlex.errors.ParsingError: unexpected token '"$(arch)"' (position 6)
```

At some point the root cause must be addressed, but given the time constraints, I'd like to suggest the following change for now, just to make our parser happy for the time being and proceed with the onboarding of this image into OCP 4.11.