### PR TITLE
NO-ISSUE: fix smartmontools installation in U/S image

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -17,11 +17,7 @@ RUN dnf install -y \
 		findutils iputils \
 		podman \
 		# inventory
-		dmidecode ipmitool biosdevname file fio \
-        # Since centos:8 is using an older version of smartmontools (smartctl needed for the inventory command), we download the fedora 32 RPM package and
-        # install it instead of using the centos repos. (We need version 7.1+ for the `--json=c` flag to work)
-        # Note that doing this is NOT needed in the downstream Dockerfile, the base image used there is openshift/ose-base:ubi8 and it has the 7.1 version of smartmontools in the repos
-        https://download-cc-rdu01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/s/smartmontools-7.1-8.fc32.x86_64.rpm \
+		dmidecode ipmitool biosdevname file fio smartmontools \
 		# free_addresses
 		nmap \
 		# dhcp_lease_allocate


### PR DESCRIPTION
We currently cannot access RPM for package smartmontools:
```
[MIRROR] smartmontools-7.1-8.fc32.x86_64.rpm: Status code: 404 for
https://download-cc-rdu01.fedoraproject.org/pub/fedora/linux/releases/32/Everything/x86_64/os/Packages/s/smartmontools-7.1-8.fc32.x86_64.rpm
(IP: 8.43.85.72)
```

(see
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-installer-agent-release-ocm-2.4-subsystem-test-periodic/1533970131380604928)

This is probably because F32 is EOL since 2021-05-25 so packages no
longer persistent in their registries.

Trying locally to install it, it seems like
`quay.io/centos/centos:stream8` has an updated version of the package
(>=7.1), and so the image used in CI.