### PR TITLE
ART-4057: Only install `dmidecode` on x86_64 and aarch64

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -21,7 +21,8 @@ COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/domain_resolution /usr/bin/domain_resolution
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/scripts/installer/* /usr/local/bin/
 
-RUN test "$(arch)" -eq "x86_64" && { dnf install -y biosdevname && dnf clean all; } || true
-RUN dnf install -y dhclient dmidecode file findutils fio ipmitool iputils nmap openssh-clients podman chrony smartmontools && dnf clean all
+RUN test "$(arch)" -eq "x86_64" && { dnf install -y biosdevname dmidecode && dnf clean all; } || true
+RUN test "$(arch)" -eq "aarch64" && { dnf install -y dmidecode && dnf clean all; } || true
+RUN dnf install -y dhclient file findutils fio ipmitool iputils nmap openssh-clients podman chrony smartmontools && dnf clean all
 
 ENTRYPOINT ["/usr/bin/agent"]


### PR DESCRIPTION
dmidecode package is not available for ppc64le and s390x arches.