### PR TITLE
AGENT-75: Add assisted installer images into OCP playload for Agent Work

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -7,6 +7,8 @@ RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 
+LABEL io.openshift.release.operator=true
+
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/agent /usr/bin/agent
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/connectivity_check /usr/bin/connectivity_check
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/inventory /usr/bin/inventory


### PR DESCRIPTION
Once the images are building successfully in OSBS (and only then), they can be added to the release payload image by setting a label in the Dockerfile:

`LABEL io.openshift.release.operator=true`