### PR TITLE
NO_ISSUE: fix mock generation.

### DIFF
--- a/src/inventory/interfaces_test.go
+++ b/src/inventory/interfaces_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Interfaces", func() {
 	})
 
 	It("Single result", func() {
-		interfaceMock := util.NewFilledInterfaceMock(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, true, false, false, 1000, "physical")
+		interfaceMock := newMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, 1000, "physical")
 		dependencies.On("Interfaces").Return([]util.Interface{interfaceMock}, nil).Once()
 		dependencies.On("Execute", "biosdevname", "-i", "eth0").Return("em2", "", 0).Once()
 		dependencies.On("ReadFile", "/sys/class/net/eth0/carrier").Return([]byte("1\n"), nil).Once()
@@ -73,11 +73,11 @@ var _ = Describe("Interfaces", func() {
 	})
 	It("Multiple results", func() {
 		rets := []util.Interface{
-			util.NewFilledInterfaceMock(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "192.168.6.7/20", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, true, false, false, 100, "physical"),
-			util.NewFilledInterfaceMock(1400, "eth1", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.19/24", "192.168.6.8/20", "fe80::d832:8def:dd51:3528/127", "de90::d832:8def:dd51:3528/127"}, true, false, false, 10, "physical"),
-			util.NewFilledInterfaceMock(1400, "eth2", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.20/24", "192.168.6.9/20", "fe80::d832:8def:dd51:3529/126", "de90::d832:8def:dd51:3529/126"}, false, false, false, 5, ""),
-			util.NewFilledInterfaceMock(1400, "bond0", "f8:75:a4:a4:00:fd", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.21/24", "192.168.6.10/20", "fe80::d832:8def:dd51:3529/125", "de90::d832:8def:dd51:3529/125"}, false, true, false, -1, "bond"),
-			util.NewFilledInterfaceMock(1400, "eth2.10", "f8:75:a4:a4:00:fc", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.25/24", "192.168.6.14/20", "fe80::d832:8def:dd51:3520/125", "de90::d832:8def:dd51:3520/125"}, false, false, true, -1, "vlan"),
+			newMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "192.168.6.7/20", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, 100, "physical"),
+			newMockInterface(1400, "eth1", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.19/24", "192.168.6.8/20", "fe80::d832:8def:dd51:3528/127", "de90::d832:8def:dd51:3528/127"}, 10, "physical"),
+			newMockInterface(1400, "eth2", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.20/24", "192.168.6.9/20", "fe80::d832:8def:dd51:3529/126", "de90::d832:8def:dd51:3529/126"}, 5, ""),
+			newMockInterface(1400, "bond0", "f8:75:a4:a4:00:fd", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.21/24", "192.168.6.10/20", "fe80::d832:8def:dd51:3529/125", "de90::d832:8def:dd51:3529/125"}, -1, "bond"),
+			newMockInterface(1400, "eth2.10", "f8:75:a4:a4:00:fc", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.25/24", "192.168.6.14/20", "fe80::d832:8def:dd51:3520/125", "de90::d832:8def:dd51:3520/125"}, -1, "vlan"),
 		}
 		dependencies.On("Interfaces").Return(rets, nil).Once()
 		dependencies.On("Execute", "biosdevname", "-i", "eth0").Return("em2", "", 0).Once()
@@ -195,3 +195,9 @@ var _ = Describe("Interfaces", func() {
 		}
 	})
 })
+
+func newMockInterface(mtu int, name string, macAddr string, flags net.Flags, addrs []string, speedMbps int64, interfaceType string) *util.MockInterface {
+	interfaceMock := util.MockInterface{}
+	util.FillInterfaceMock(&interfaceMock.Mock, mtu, name, macAddr, flags, addrs, speedMbps, interfaceType)
+	return &interfaceMock
+}

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -81,8 +81,8 @@ var _ = Describe("Machine uuid test", func() {
 
 		It(fmt.Sprintf("mac address fallback %s", test.useCase), func() {
 			rets := []agentutils.Interface{
-				agentutils.NewFilledInterfaceMock(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "192.168.6.7/20", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, true, false, false, 100, "physical"),
-				agentutils.NewFilledInterfaceMock(1400, "eth1", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.19/24", "192.168.6.8/20", "fe80::d832:8def:dd51:3528/127", "de90::d832:8def:dd51:3528/127"}, true, false, false, 10, "physical"),
+				newMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "192.168.6.7/20", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, 100, "physical"),
+				newMockInterface(1400, "eth1", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.19/24", "192.168.6.8/20", "fe80::d832:8def:dd51:3528/127", "de90::d832:8def:dd51:3528/127"},10, "physical"),
 			}
 			dependencies.On("Interfaces").Return(rets, nil).Once()
 			dependencies.On("Execute", "biosdevname", "-i", "eth0").Return("em2", "", 0).Once()
@@ -117,4 +117,10 @@ var _ = Describe("Machine uuid test", func() {
 func TestSubsystem(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Scanner unit tests")
+}
+
+func newMockInterface(mtu int, name string, macAddr string, flags net.Flags, addrs []string, speedMbps int64, interfaceType string) *agentutils.MockInterface {
+	interfaceMock := agentutils.MockInterface{}
+	agentutils.FillInterfaceMock(&interfaceMock.Mock, mtu, name, macAddr, flags, addrs, speedMbps, interfaceType)
+	return &interfaceMock
 }

--- a/src/util/mocks.go
+++ b/src/util/mocks.go
@@ -1,42 +1,10 @@
 package util
 
 import (
-	"net"
-
 	netlink "github.com/vishvananda/netlink"
 )
 
 //go:generate mockery -name Link -inpkg
 type Link interface {
 	netlink.Link
-}
-
-func NewFilledInterfaceMock(mtu int, name string, macAddr string, flags net.Flags, addrs []string, isPhysical bool, isBonding bool, isVlan bool, speedMbps int64, interfaceType string) *MockInterface {
-	hwAddr, _ := net.ParseMAC(macAddr)
-	ret := MockInterface{}
-	ret.On("Name").Return(name)
-	ret.On("MTU").Return(mtu)
-	ret.On("HardwareAddr").Return(hwAddr)
-	ret.On("Flags").Return(flags)
-	ret.On("Addrs").Return(toAddresses(addrs), nil).Once()
-	ret.On("SpeedMbps").Return(speedMbps)
-	ret.On("Type").Return(interfaceType, nil).Once()
-
-	return &ret
-}
-
-func toAddresses(addrs []string) []net.Addr {
-	ret := make([]net.Addr, 0)
-	for _, a := range addrs {
-		ret = append(ret, str2Addr(a))
-	}
-	return ret
-}
-
-func str2Addr(addrStr string) net.Addr {
-	ip, ipnet, err := net.ParseCIDR(addrStr)
-	if err != nil {
-		return &net.IPNet{}
-	}
-	return &net.IPNet{IP: ip, Mask: ipnet.Mask}
 }

--- a/src/util/test_utils.go
+++ b/src/util/test_utils.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"github.com/stretchr/testify/mock"
+	"net"
+)
+
+func FillInterfaceMock(mock *mock.Mock,mtu int, name string, macAddr string, flags net.Flags, addrs []string, speedMbps int64, interfaceType string) {
+	mock.On("Name").Return(name)
+	mock.On("MTU").Return(mtu)
+	hwAddr, _ := net.ParseMAC(macAddr)
+	mock.On("HardwareAddr").Return(hwAddr)
+	mock.On("Flags").Return(flags)
+	mock.On("Addrs").Return(parseAddresses(addrs), nil).Once()
+	mock.On("SpeedMbps").Return(speedMbps)
+	mock.On("Type").Return(interfaceType, nil).Once()
+}
+
+func parseAddresses(addrs []string) []net.Addr {
+	ret := make([]net.Addr, 0)
+	for _, a := range addrs {
+		ret = append(ret, parseAddress(a))
+	}
+	return ret
+}
+
+func parseAddress(addrStr string) net.Addr {
+	ip, ipnet, err := net.ParseCIDR(addrStr)
+	if err != nil {
+		return &net.IPNet{}
+	}
+	return &net.IPNet{IP: ip, Mask: ipnet.Mask}
+}


### PR DESCRIPTION
go generate command failed when the package uses the generated code
The make generate target deletes the old mocks before regenerating them
mocks.go file used util.MockInterface type so after the deletion the compilation failed which fails the mock generation for this package
Using mock.Mock embedded object instead