### PR TITLE
AGENT-263: Remove ENTRYPOINT from OCP Dockerfile

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -23,6 +23,6 @@ COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/domain_resolution /usr/bin/domain_resolution
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/scripts/installer/* /usr/local/bin/
 
-RUN test "$(arch)" -eq "x86_64" && { dnf install -y biosdevname dmidecode && dnf clean all; } || true
-RUN test "$(arch)" -eq "aarch64" && { dnf install -y dmidecode && dnf clean all; } || true
+RUN if [ "$(arch)" -eq "x86_64" ]; then dnf install -y biosdevname dmidecode; fi
+RUN if [ "$(arch)" -eq "aarch64" ]; then dnf install -y dmidecode; fi
 RUN dnf install -y dhclient file findutils fio ipmitool iputils nmap openssh-clients podman chrony smartmontools && dnf clean all

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -26,5 +26,3 @@ COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/script
 RUN test "$(arch)" -eq "x86_64" && { dnf install -y biosdevname dmidecode && dnf clean all; } || true
 RUN test "$(arch)" -eq "aarch64" && { dnf install -y dmidecode && dnf clean all; } || true
 RUN dnf install -y dhclient file findutils fio ipmitool iputils nmap openssh-clients podman chrony smartmontools && dnf clean all
-
-ENTRYPOINT ["/usr/bin/agent"]


### PR DESCRIPTION
We don't actually run the agent from within the container (instead it's
first copied to the host filesystem), so specifying an ENTRYPOINT is
actually unhelpful.