### PR TITLE
MGMT-10973: Filtered ignition should keep non-heavy elements

### DIFF
--- a/src/apivip_check/apivip_check.go
+++ b/src/apivip_check/apivip_check.go
@@ -75,7 +75,12 @@ func copyIgnitionManagedNetworkIndications(originalConfig *ignition_types.Config
 // only those needed by the service. We do this because the ignition config
 // tends to be quite large.
 func filterIgnition(originalConfig *ignition_types.Config) *ignition_types.Config {
-	filteredConfig := ignition_types.Config{}
+	// Marshal then parse for the sake of cloning
+	config, _ := json.Marshal(originalConfig)
+	filteredConfig, _, _ := v3_2.Parse(config)
+
+	filteredConfig.Storage.Files = []ignition_types.File{}
+	filteredConfig.Systemd.Units = []ignition_types.Unit{}
 
 	copyIgnitionDiskEncryptionInformation(originalConfig, &filteredConfig)
 	copyIgnitionManagedNetworkIndications(originalConfig, &filteredConfig)


### PR DESCRIPTION
Currently, we filter the ignition file by removing literally everything
from it except for a few very specific files and the LUKS information.

The resulting ignition from such filtering process is completely
unparsable by the service as it doesn't even contain which version
of ignition it is.

This means that the feature that dependened on it, such as day-2 disk
encryption, did not work.

It was also a blocker for [MGMT-10973](https://issues.redhat.com//browse/MGMT-10973) (single node imported cluster DNS
validation, see 15557354b2e2d92afa46d36004153315c30c1d16).

This commit makes it so that instead of starting with an empty ignition
and then adding just the files we want, instead we will start with a
full ignition, delete just the very heavy parts (the systemd units
and storage files), and only then add the files we want..

This makes it so that important information such as the version and
other lightweight information in the ignition are preserved and that
will allow the service to parse the ignition without any issues.