### PR TITLE
MGMT-11262: Include `/etc/kubernetes/kubeconfig` in day-2 ignition

### DIFF
--- a/src/apivip_check/apivip_check.go
+++ b/src/apivip_check/apivip_check.go
@@ -69,6 +69,12 @@ func copyIgnitionManagedNetworkIndications(originalConfig *ignition_types.Config
 	// and fully move to the new one by inspecting that file instead.
 	copyIgnitionFile(originalConfig, filteredConfig, "/etc/kubernetes/manifests/coredns.yaml")
 	copyIgnitionFile(originalConfig, filteredConfig, "/etc/kubernetes/manifests/keepalived.yaml")
+
+	// Some clusters (like hypershift) don't use a domain name at all to
+	// connect to the cluster, the service can tell if this is the case by
+	// looking at the IP address of the kubeconfig within the ignition, so the
+	// agent should include that file for the service
+	copyIgnitionFile(originalConfig, filteredConfig, "/etc/kubernetes/kubeconfig")
 }
 
 // filterIgnition removes unnecessary sections of the ignition config, leaving


### PR DESCRIPTION
When the ignition downloaded by the day-2 worker discovery indicates
that kubelet is connecting to the day-1 cluster using an IP address
rather than a domain name, we can safely disable DNS validations for
that worker in day-2.

This is the case in Hypershift.

The service should also be modified to detect this situation and disable
DNS validations when it's detected.

The agent should be modified to include /etc/kubernetes/kubeconfig in
the day-2 ignition, because right now it's omitted for size concerns