### PR TITLE
MGMT-11356: Add option to log to stdout

### DIFF
--- a/src/agent/main/main.go
+++ b/src/agent/main/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	agentConfig := config.ProcessArgs()
 	config.ProcessDryRunArgs(&agentConfig.DryRunConfig)
-	util.SetLogging("agent_registration", agentConfig.TextLogging, agentConfig.JournalLogging, agentConfig.ForcedHostID)
+	util.SetLogging("agent_registration", agentConfig.TextLogging, agentConfig.JournalLogging, agentConfig.StdoutLogging, agentConfig.ForcedHostID)
 	nextStepRunnerFactory := agent.NewNextStepRunnerFactory()
 	agent.RunAgent(agentConfig, nextStepRunnerFactory, logrus.StandardLogger())
 }

--- a/src/apivip_check/main/main.go
+++ b/src/apivip_check/main/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
-	util.SetLogging("apivip_check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	util.SetLogging("apivip_check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Warnf("Expecting exactly single argument to apivip_check. Received %d", len(os.Args)-1)
 		os.Exit(-1)

--- a/src/config/agent_config.go
+++ b/src/config/agent_config.go
@@ -28,6 +28,7 @@ func ProcessArgs() *AgentConfig {
 	flag.IntVar(&ret.IntervalSecs, "interval", 60, "Interval between steps polling in seconds")
 	flag.BoolVar(&ret.JournalLogging, "with-journal-logging", true, "Use journal logging")
 	flag.BoolVar(&ret.TextLogging, "with-text-logging", false, "Output log to file")
+	flag.BoolVar(&ret.StdoutLogging, "with-stdout-logging", false, "Output log to stdout")
 	flag.StringVar(&ret.CACertificatePath, "cacert", "", "Path to custom CA certificate in PEM format")
 	flag.BoolVar(&ret.InsecureConnection, "insecure", false, "Do not validate TLS certificate")
 	flag.StringVar(&ret.HostID, "host-id", "", "Host identification")

--- a/src/config/subprocess_config.go
+++ b/src/config/subprocess_config.go
@@ -6,6 +6,7 @@ import "flag"
 type LoggingConfig struct {
 	TextLogging    bool
 	JournalLogging bool
+	StdoutLogging  bool
 }
 
 // SubprocessConfig processe's logging configuration
@@ -18,6 +19,7 @@ type SubprocessConfig struct {
 var DefaultLoggingConfig = LoggingConfig{
 	TextLogging:    false,
 	JournalLogging: true,
+	StdoutLogging:  false,
 }
 
 // ProcessSubprocessArgs parses arguments
@@ -25,6 +27,7 @@ func ProcessSubprocessArgs(loggingDefaults LoggingConfig) *SubprocessConfig {
 	subprocessConfig := &SubprocessConfig{}
 	flag.BoolVar(&subprocessConfig.JournalLogging, "with-journal-logging", loggingDefaults.JournalLogging, "Use journal logging")
 	flag.BoolVar(&subprocessConfig.TextLogging, "with-text-logging", loggingDefaults.TextLogging, "Use text logging")
+	flag.BoolVar(&subprocessConfig.TextLogging, "with-stdout-logging", loggingDefaults.StdoutLogging, "Use stdout logging")
 	h := flag.Bool("help", false, "Help message")
 	flag.Parse()
 	if h != nil && *h {

--- a/src/connectivity_check/main/main.go
+++ b/src/connectivity_check/main/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
-	util.SetLogging("connectivity-check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	util.SetLogging("connectivity-check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Warnf("Expecting exactly single argument to connectivity check. Received %d", len(os.Args)-1)
 		os.Exit(-1)

--- a/src/container_image_availability/main/main.go
+++ b/src/container_image_availability/main/main.go
@@ -33,7 +33,7 @@ func main() {
 	processArgs()
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
-	util.SetLogging("container_image_availability", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	util.SetLogging("container_image_availability", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 	log.StandardLogger().Infof("Checking image availability, requested images: %s", executableConfig.Request)
 	stdout, stderr, exitCode := container_image_availability.Run(subprocessConfig, executableConfig.Request,
 		&container_image_availability.ProcessExecuter{}, log.StandardLogger())

--- a/src/dhcp_lease_allocate/main/main.go
+++ b/src/dhcp_lease_allocate/main/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
-	util.SetLogging("dhcp_lease_allocate", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	util.SetLogging("dhcp_lease_allocate", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Warnf("Expecting exactly single argument to dhcp_lease_allocate. Received %d", len(os.Args)-1)
 		os.Exit(-1)

--- a/src/disk_speed_check/main/main.go
+++ b/src/disk_speed_check/main/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
-	util.SetLogging("disk-speed-check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	util.SetLogging("disk-speed-check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 
 	req := flag.Arg(flag.NArg() - 1)
 	perfCheck := disk_speed_check.NewDiskSpeedCheck(subprocessConfig, disk_speed_check.NewDependencies())

--- a/src/domain_resolution/main/main.go
+++ b/src/domain_resolution/main/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	util.SetLogging("domain_resolution",
 		subprocessConfig.TextLogging,
-		subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+		subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 
 	log.StandardLogger().Infof("Processing domain resolution, requested domains: %s", request)
 

--- a/src/free_addresses/main/main.go
+++ b/src/free_addresses/main/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
-	util.SetLogging("free_addresses", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	util.SetLogging("free_addresses", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Warnf("Expecting exactly single argument to free_addresses. Received %d", len(os.Args)-1)
 		os.Exit(-1)

--- a/src/inventory/main/main.go
+++ b/src/inventory/main/main.go
@@ -11,6 +11,6 @@ import (
 func main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
-	util.SetLogging("inventory", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	util.SetLogging("inventory", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 	fmt.Print(string(inventory.CreateInventoryInfo(subprocessConfig)))
 }

--- a/src/logs_sender/main/main.go
+++ b/src/logs_sender/main/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	loggingConfig := config.ProcessLogsSenderConfigArgs(true, true)
 	config.ProcessDryRunArgs(&loggingConfig.DryRunConfig)
-	util.SetLoggingWithStdOut("logs-sender", loggingConfig.TextLogging, loggingConfig.JournalLogging, loggingConfig.ForcedHostID)
+	util.SetLogging("logs-sender", loggingConfig.TextLogging, loggingConfig.JournalLogging, loggingConfig.StdoutLogging, loggingConfig.ForcedHostID)
 	err, report := logs_sender.SendLogs(loggingConfig, logs_sender.NewLogsSenderExecuter(loggingConfig, loggingConfig.TargetURL,
 		loggingConfig.PullSecretToken,
 		loggingConfig.AgentVersion))

--- a/src/next_step_runner/main/main.go
+++ b/src/next_step_runner/main/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	agentConfig := config.ProcessArgs()
 	config.ProcessDryRunArgs(&agentConfig.DryRunConfig)
-	util.SetLogging("agent_next_step_runner", agentConfig.TextLogging, agentConfig.JournalLogging, agentConfig.ForcedHostID)
+	util.SetLogging("agent_next_step_runner", agentConfig.TextLogging, agentConfig.JournalLogging, agentConfig.StdoutLogging, agentConfig.ForcedHostID)
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)

--- a/src/ntp_synchronizer/main/main.go
+++ b/src/ntp_synchronizer/main/main.go
@@ -18,7 +18,7 @@ func DryRunNtp() (string, string, int) {
 func main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
-	util.SetLogging("ntp_synchronizer", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.ForcedHostID)
+	util.SetLogging("ntp_synchronizer", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 	if flag.NArg() != 1 {
 		log.Fatalf("Expecting exactly single argument to ntp_synchronizer. Received %d", len(os.Args)-1)
 	}

--- a/src/util/logging.go
+++ b/src/util/logging.go
@@ -79,12 +79,8 @@ func setLogging(logger *logrus.Logger, journalWriter journalLogger.IJournalWrite
 	}
 }
 
-func SetLoggingWithStdOut(name string, textLogging, journalLogging bool, hostID string) {
-	setLogging(logrus.StandardLogger(), &journalLogger.JournalWriter{}, name, textLogging, journalLogging, true, hostID)
-}
-
-func SetLogging(name string, textLogging, journalLogging bool, hostID string) {
-	setLogging(logrus.StandardLogger(), &journalLogger.JournalWriter{}, name, textLogging, journalLogging, false, hostID)
+func SetLogging(name string, textLogging, journalLogging, stdoutLogging bool, hostID string) {
+	setLogging(logrus.StandardLogger(), &journalLogger.JournalWriter{}, name, textLogging, journalLogging, stdoutLogging, hostID)
 }
 
 func NewJournalLogger(name string, hostID string) logrus.FieldLogger {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11356
Previously the agent only allowed logging to
either the journal or to a log file. This doesn't
allow logging to stdout, which is needed if the
agent runs in a pod.

This adds the option to log to stdout. This can
be specified when running the agent with the flag
`--with-stdout-logging true`

/cc @carbonin 

Tested by running the agent in a pod with the argument `-with-stdout-logging=true` in the pod spec and running `oc logs <pod name>`