### PR TITLE
MGMT-11527: fix flaky golangci-lint installation

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -4,7 +4,7 @@ ENV GOFLAGS=""
 
 RUN yum install -y docker docker-compose && \
     yum clean all
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
+COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
 RUN go get -u golang.org/x/tools/cmd/goimports@v0.1.0 \
               github.com/onsi/ginkgo/ginkgo@v1.16.1  \
               github.com/golang/mock/mockgen@v1.4.3  \


### PR DESCRIPTION
We sometimes get the following flake:

```
golangci/golangci-lint info checking GitHub for tag 'v1.24.0'
golangci/golangci-lint crit unable to find 'v1.24.0' - use 'latest' or
see https://github.com/golangci/golangci-lint/releases for details
```

(see https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-installer-agent-release-ocm-2.6-subsystem-test-periodic/1556051193472487424)

This means we're doing too many requests to GitHub's API and getting holded by its rate-limiter.

The suggested change is using pre-built images, which are already getting mirrored to quay.io (and to internal prow registry), hopefully getting much less problems with this setup.