### PR TITLE
MGMT-11575: Ignore empty MAC address for host UUID generation

### DIFF
--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -81,10 +81,15 @@ var _ = Describe("Machine uuid test", func() {
 
 		It(fmt.Sprintf("mac address fallback %s", test.useCase), func() {
 			rets := []agentutils.Interface{
+				newMockInterface(65536, "lo", "", net.FlagBroadcast|net.FlagLoopback, []string{"127.0.0.1/8"}, 100, "physical"),
 				newMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagBroadcast|net.FlagUp, []string{"10.0.0.18/24", "192.168.6.7/20", "fe80::d832:8def:dd51:3527/128", "de90::d832:8def:dd51:3527/128"}, 100, "physical"),
 				newMockInterface(1400, "eth1", "f8:75:a4:a4:00:ff", net.FlagBroadcast|net.FlagLoopback, []string{"10.0.0.19/24", "192.168.6.8/20", "fe80::d832:8def:dd51:3528/127", "de90::d832:8def:dd51:3528/127"}, 10, "physical"),
 			}
 			dependencies.On("Interfaces").Return(rets, nil).Once()
+			dependencies.On("Execute", "biosdevname", "-i", "lo").Return("em2", "", 0).Once()
+			dependencies.On("ReadFile", "/sys/class/net/lo/carrier").Return([]byte("0\n"), nil).Once()
+			dependencies.On("ReadFile", "/sys/class/net/lo/device/device").Return([]byte("my-device1"), nil).Once()
+			dependencies.On("ReadFile", "/sys/class/net/lo/device/vendor").Return([]byte("my-vendor1"), nil).Once()
 			dependencies.On("Execute", "biosdevname", "-i", "eth0").Return("em2", "", 0).Once()
 			dependencies.On("ReadFile", "/sys/class/net/eth0/carrier").Return([]byte("0\n"), nil).Once()
 			dependencies.On("ReadFile", "/sys/class/net/eth0/device/device").Return([]byte("my-device1"), nil).Once()


### PR DESCRIPTION
When falling back to MAC generated host UUID , we have loopback device in the list of interfaces with empty UUID

If this interface gets picked up to be the one to generate the UUID (and it does, since the sorting provokes that it ends up always being the first element), it will create always the same UUID for all hosts:

```
Aug 10 13:27:38 109-74-204-122 agent[5130]: time="10-08-2022 13:27:38" level=info msg="Using mac from interface lo to provide node-uuid" file="machine_uuid_scanner.go:118"
```

cc: @avishayt 
cc: @filanov 