### PR TITLE
MGMT-11185: disk_speed_check: escape colons when calling fio

### DIFF
--- a/src/disk_speed_check/disk_speed_check.go
+++ b/src/disk_speed_check/disk_speed_check.go
@@ -2,6 +2,7 @@ package disk_speed_check
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -100,7 +101,9 @@ func (p *DiskSpeedCheck) getDiskPerf(path string) fioCheckResponse {
 		return fioCheckResponse{latency: time.Duration(dryModeSyncDurationInNS).Milliseconds(), err: nil}
 	}
 
-	args := []string{"--filename", path, "--name=test", "--rw=write", "--ioengine=sync",
+	// FIO treats colons as multiple device separator, which breaks paths like /dev/disk/by-path/pci-0000:06:0000.0
+	escaped_path := strings.ReplaceAll(path, ":", "\\:")
+	args := []string{"--filename", escaped_path, "--name=test", "--rw=write", "--ioengine=sync",
 		"--size=22m", "-bs=2300", "--fdatasync=1", "--output-format=json"}
 	stdout, stderr, exitCode := p.dependecies.Execute("fio", args...)
 	if exitCode != 0 {


### PR DESCRIPTION
fio's filename can be a colon-separated list of devices to test. This however breaks some paths with colons, so these need to be escaped.
See https://fio.readthedocs.io/en/latest/fio_doc.html#cmdoption-arg-filename