### PR TITLE
MGMT-12030: Pinning golang.org/x/sys dependency due to golang incompatibility

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -11,4 +11,5 @@ RUN go get -u golang.org/x/tools/cmd/goimports@v0.1.0 \
               github.com/vektra/mockery/.../@v1.1.2 \
               gotest.tools/gotestsum@v1.6.3 \
               github.com/axw/gocov/gocov \
+              golang.org/x/sys@v0.0.0-20220908164124-27713097b956 \
               github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737


### PR DESCRIPTION
Fix getting this in some jobs:
```
go: downloading golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2
go: downloading golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
go: downloading golang.org/x/term v0.0.0-20220722155259-a9ba230a4035
go: downloading github.com/vektra/mockery v1.1.2
go: downloading github.com/stretchr/testify v1.7.1
go: downloading github.com/stretchr/testify v1.8.0
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/stretchr/objx v0.1.1
go: downloading gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
go: downloading github.com/stretchr/objx v0.4.0
go: downloading gopkg.in/yaml.v3 v3.0.1
# golang.org/x/sys/unix
/go/pkg/mod/golang.org/x/sys@v0.0.0-20220909162455-aba9fc2a8ff2/unix/syscall.go:83:7: undefined: unsafe.Slice
/go/pkg/mod/golang.org/x/sys@v0.0.0-20220909162455-aba9fc2a8ff2/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
/go/pkg/mod/golang.org/x/sys@v0.0.0-20220909162455-aba9fc2a8ff2/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice
```

For example: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-installer-agent-release-ocm-2.4-subsystem-test-periodic/1569484012206952448