### PR TITLE
Update approvers and reviewers lists

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,10 +3,11 @@
 filters:
   .*:
     approvers:
-      - code-approvers
+      - approvers
+    emeritus_approvers:
+      - emeritus_approvers
     reviewers:
-      - code-approvers
-      - code-reviewers
+      - approvers
   ^Dockerfile\..*:
     labels:
       - downstream-change-needed

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,37 +1,29 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 aliases:
-  code-approvers:
+  approvers:
     - avishayt
-    - empovit
     - eranco74
     - filanov
     - gamli75
     - ori-amizur
-    - oshercc
     - romfreiman
     - tsorya
-    - yevgeny-shnaidman
     - nmagnezi
     - carbonin
-    - rollandf
     - danielerez
-    - ybettan
     - slaviered
     - osherdp
     - omertuc
-    - michaellevy101
     - mkowalski
     - eliorerz
     - flaper87
-    - lranjbar
     - paul-maidment
     - rccrdpccl
     - jhernand
     - vrutkovs
-  code-reviewers:
-    - jakub-dzon
-    - pkliczewski
-    - masayag
-    - jordigilh
-    - machacekondra
+  emeritus_approvers:
+    - empovit
+    - yevgeny-shnaidman
+    - lranjbar
+    - ybettan


### PR DESCRIPTION
What
----

This change updates the lists and makes some cleanups and refactorings to the way we're handling those lists of approvers/reviewers.

Why
---

Changing the appropriate lists have the potential to improve the following aspects:
- Prow uses those lists to automatically mention (``/auto-cc``) several point-of-contacts. It should consider availability of the member, but it does ignore members' that are more active in a repo. It means some members might get a little more noise in their emails / github notifications while other more relevant members might miss some important notification for the relevant changes.
- PR authors (especially newcomers) will have it easy to understand who they should reach for the review / testing processes.

How
---

I mostly used ``git shortlog -s -n --no-merges --since "2022-01-01"`` to understand who are the recent contributers for the repo and also team's association. (e.g. members that are part of the nvidia-GPU team)

FAQ
---

Q: If I'm out of 'reviewers' list. Does it mean I won't be able to
   ``/lgtm``?
A: Not for all I know. Everyone in the ``openshift`` organization should
   be able to ``/lgtm``. This list is for choosing good candidates for
   lgtm-ing while it automatically chooses reviewers. Read more about it
   here: https://www.kubernetes.dev/docs/guide/owners/#owners

Q: I'm an approver and I need to stay an approver. A: No problem. Reach out either in this PR or privately and I'll gladly
   make the adjustments.

Q: What the ``emeritus_approvers`` means?
A: It's mainly a documentation title for all I know, that doesn't grant
   the ability to do ``/approve``. It's a good way to annotate some
   member as previous approver, that can return being an approver in the
   future as needed. So it's a good way to transition ownership. Read
   more about it here:
   https://www.kubernetes.dev/docs/guide/owners/#emeritus

/cc empovit yevgeny-shnaidman lranjbar jakub-dzon pkliczewski masayag jordigilh machacekondra
/hold