### PR TITLE
MGMT-12139: Add offset to FIO disk speed check

### DIFF
--- a/src/disk_speed_check/disk_speed_check.go
+++ b/src/disk_speed_check/disk_speed_check.go
@@ -104,7 +104,7 @@ func (p *DiskSpeedCheck) getDiskPerf(path string) fioCheckResponse {
 	// FIO treats colons as multiple device separator, which breaks paths like /dev/disk/by-path/pci-0000:06:0000.0
 	escaped_path := strings.ReplaceAll(path, ":", "\\:")
 	args := []string{"--filename", escaped_path, "--name=test", "--rw=write", "--ioengine=sync",
-		"--size=22m", "-bs=2300", "--fdatasync=1", "--output-format=json"}
+		"--size=22m", "-bs=2300", "--fdatasync=1", "--offset=1M", "--output-format=json"}
 	stdout, stderr, exitCode := p.dependecies.Execute("fio", args...)
 	if exitCode != 0 {
 		err := errors.Errorf("Could not get I/O performance for path %s (fio exit code: %d, stderr: %s)",

--- a/src/disk_speed_check/disk_speed_check_test.go
+++ b/src/disk_speed_check/disk_speed_check_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Disk speed check test", func() {
 		durationInNS := durationInMS * int64(time.Millisecond)
 		dependencies.On("Execute", "fio", "--filename", file,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything).Return(fmt.Sprintf(
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Sprintf(
 			`{ "jobs": 
 					[{
 						"sync":
@@ -53,7 +53,7 @@ var _ = Describe("Disk speed check test", func() {
 	fioFailure := func(file string) {
 		dependencies.On("Execute", "fio", "--filename", file,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything).Return("", "failure", -1).Once()
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", "failure", -1).Once()
 	}
 
 	It("Check succeeded", func() {


### PR DESCRIPTION
By adding an offset, the disk_speed_check will not delete the partition table, allowing for subsequent steps to run properly

/cc @paul-maidment 