### PR TITLE
MGMT-12139: Revert disk_speed_check related changes

### DIFF
--- a/src/disk_speed_check/disk_speed_check.go
+++ b/src/disk_speed_check/disk_speed_check.go
@@ -2,7 +2,6 @@ package disk_speed_check
 
 import (
 	"encoding/json"
-	"strings"
 	"sync"
 	"time"
 
@@ -101,9 +100,7 @@ func (p *DiskSpeedCheck) getDiskPerf(path string) fioCheckResponse {
 		return fioCheckResponse{latency: time.Duration(dryModeSyncDurationInNS).Milliseconds(), err: nil}
 	}
 
-	// FIO treats colons as multiple device separator, which breaks paths like /dev/disk/by-path/pci-0000:06:0000.0
-	escaped_path := strings.ReplaceAll(path, ":", "\\:")
-	args := []string{"--filename", escaped_path, "--name=test", "--rw=write", "--ioengine=sync",
+	args := []string{"--filename", path, "--name=test", "--rw=write", "--ioengine=sync",
 		"--size=22m", "-bs=2300", "--fdatasync=1", "--output-format=json"}
 	stdout, stderr, exitCode := p.dependecies.Execute("fio", args...)
 	if exitCode != 0 {

--- a/src/disk_speed_check/disk_speed_check.go
+++ b/src/disk_speed_check/disk_speed_check.go
@@ -104,7 +104,7 @@ func (p *DiskSpeedCheck) getDiskPerf(path string) fioCheckResponse {
 	// FIO treats colons as multiple device separator, which breaks paths like /dev/disk/by-path/pci-0000:06:0000.0
 	escaped_path := strings.ReplaceAll(path, ":", "\\:")
 	args := []string{"--filename", escaped_path, "--name=test", "--rw=write", "--ioengine=sync",
-		"--size=22m", "-bs=2300", "--fdatasync=1", "--offset=1M", "--output-format=json"}
+		"--size=22m", "-bs=2300", "--fdatasync=1", "--output-format=json"}
 	stdout, stderr, exitCode := p.dependecies.Execute("fio", args...)
 	if exitCode != 0 {
 		err := errors.Errorf("Could not get I/O performance for path %s (fio exit code: %d, stderr: %s)",

--- a/src/disk_speed_check/disk_speed_check_test.go
+++ b/src/disk_speed_check/disk_speed_check_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Disk speed check test", func() {
 		durationInNS := durationInMS * int64(time.Millisecond)
 		dependencies.On("Execute", "fio", "--filename", file,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Sprintf(
+			mock.Anything, mock.Anything, mock.Anything).Return(fmt.Sprintf(
 			`{ "jobs": 
 					[{
 						"sync":
@@ -53,7 +53,7 @@ var _ = Describe("Disk speed check test", func() {
 	fioFailure := func(file string) {
 		dependencies.On("Execute", "fio", "--filename", file,
 			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", "failure", -1).Once()
+			mock.Anything, mock.Anything, mock.Anything).Return("", "failure", -1).Once()
 	}
 
 	It("Check succeeded", func() {


### PR DESCRIPTION
Running `fio` the way we do creates problems with the cleanupDevice of the assisted-installer

Let's revert the changes until we find a proper solution