### PR TITLE
MGMT-8460: Automatically rename discovered hosts

### DIFF
--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -2,10 +2,14 @@ package inventory
 
 import (
 	"encoding/json"
+	"net"
+	"sort"
+	"strings"
 
 	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-installer-agent/src/util"
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
 )
 
 func ReadInventory(subprocessConfig *config.SubprocessConfig, c *Options) *models.Inventory {
@@ -24,6 +28,7 @@ func ReadInventory(subprocessConfig *config.SubprocessConfig, c *Options) *model
 		Routes:       GetRoutes(d),
 		TpmVersion:   GetTPM(d),
 	}
+	processInventory(&ret)
 	return &ret
 }
 
@@ -40,4 +45,113 @@ func CreateInventoryInfo(subprocessConfig *config.SubprocessConfig) []byte {
 
 type Options struct {
 	GhwChrootRoot string
+}
+
+// processInventory processes the inventory before sending it to the service. For example, it
+// replaces forbidden host names with automatically generated ones.
+func processInventory(inventory *models.Inventory) {
+	if isForbiddenHostname(inventory.Hostname) {
+		calculatedHostname, err := calculateHostname(inventory)
+		if err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"original": inventory.Hostname,
+			}).Error("Failed to generate hostname, will use the original forbidden one")
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"original":   inventory.Hostname,
+				"calculated": calculatedHostname,
+			}).Info("Replaced original forbidden hostname with calculated one")
+			inventory.Hostname = calculatedHostname
+		}
+	}
+}
+
+// forbidenHostnames is the set of host names that are forbidden and need to be replaced with
+// automatically generated ones.
+var forbiddenHostnames = []string{
+	"localhost",
+	"localhost.localdomain",
+	"localhost4",
+	"localhost4.localdomain4",
+	"localhost6",
+	"localhost6.localdomain6",
+}
+
+// isForbiddenHostname checks if the given string is a forbidden host name that needs to be replaced
+// with an automatically generated one.
+func isForbiddenHostname(hostname string) bool {
+	for _, forbiddenHostname := range forbiddenHostnames {
+		if hostname == forbiddenHostname {
+			return true
+		}
+	}
+	return false
+}
+
+// calculateHostname calculates a hostname from the MAC address of one of the network interfaces of
+// the given inventory. For example, if the MAC address of the network interface is
+// A8:CD:16:AE:79:01 the result will be a8-cd-16-ae-79-01.
+func calculateHostname(inventory *models.Inventory) (result string, err error) {
+	nic, err := findUsableNIC(inventory)
+	if err != nil {
+		return
+	}
+	result = strings.ToLower(strings.ReplaceAll(nic.MacAddress, ":", "-"))
+	return
+}
+
+// findUsableNIC returns a physical network interface card of the given host inventory that has a
+// MAC address and a non-local IP address. Returns nil if the host doesn't have such network
+// interface card, and an error if the process fails, for example if some of the IP addresses of the
+// host can't be parsed.
+func findUsableNIC(inventory *models.Inventory) (result *models.Interface, err error) {
+	// Sort the network interfaces by name so that the result will be deterministic:
+	nics := make([]*models.Interface, len(inventory.Interfaces))
+	copy(nics, inventory.Interfaces)
+	sort.Slice(nics, func(i, j int) bool {
+		return strings.Compare(nics[i].Name, nics[j].Name) < 0
+	})
+
+	// Find the first NIC that has a MAC address an a global IP address:
+	for _, nic := range nics {
+		isPhysical := nic.Type == "physical"
+		hasMAC := nic.MacAddress != ""
+		hasV4 := false
+		for _, ip := range nic.IPV4Addresses {
+			hasV4, err = isGlobalCIDR(ip)
+			if err != nil {
+				return
+			}
+			if hasV4 {
+				break
+			}
+		}
+		hasV6 := false
+		for _, ip := range nic.IPV6Addresses {
+			hasV6, err = isGlobalCIDR(ip)
+			if err != nil {
+				return
+			}
+			if hasV6 {
+				break
+			}
+		}
+		if isPhysical && hasMAC && (hasV4 || hasV6) {
+			result = nic
+			return
+		}
+	}
+	return
+}
+
+// isGlobalCIDR returns a boolean flag indicating if the IP address in the given CIDR is a global
+// one and not a local one like 127.0.0.1 or ::1. Returns an error if the given string can't be
+// parsed as a CIDR.
+func isGlobalCIDR(cidr string) (result bool, err error) {
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return
+	}
+	result = ip.IsGlobalUnicast()
+	return
 }

--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -1,0 +1,184 @@
+package inventory
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("Hostname processing", func() {
+	DescribeTable(
+		"Rename behaviour",
+		func(original string, interfaces []*models.Interface, expected string) {
+			// Create the inventory:
+			inventory := &models.Inventory{
+				Hostname: original,
+			}
+			inventory.Interfaces = []*models.Interface{{
+				Name:          "lo",
+				MacAddress:    "",
+				IPV4Addresses: []string{"127.0.0.1/32"},
+				IPV6Addresses: []string{"::1/128"},
+			}}
+			inventory.Interfaces = append(inventory.Interfaces, interfaces...)
+
+			// Process the inventory and check the results:
+			processInventory(inventory)
+			Expect(inventory.Hostname).To(Equal(expected))
+		},
+		Entry(
+			"Doesn't rename if already has acceptable name",
+			"myhost",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"myhost",
+		),
+		Entry(
+			"Replaces IPv4 localhost with MAC of first NIC",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"71-a0-a4-6f-be-c8",
+		),
+		Entry(
+			"Replace IPv6 localhost with MAC of first NIC",
+			"localhost6",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"71-a0-a4-6f-be-c8",
+		),
+		Entry(
+			"Ignores NIC with MAC but no IP address",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV4Addresses: []string{},
+				},
+				{
+					Name:          "eth1",
+					Type:          "physical",
+					MacAddress:    "42:5a:90:c8:24:dc",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"42-5a-90-c8-24-dc",
+		),
+		Entry(
+			"Ignores NIC with loopback IPv4 address",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV4Addresses: []string{"127.0.0.1/32"},
+				},
+				{
+					Name:          "eth1",
+					Type:          "physical",
+					MacAddress:    "42:5a:90:c8:24:dc",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"42-5a-90-c8-24-dc",
+		),
+		Entry(
+			"Ignores NIC with loopback IPv6 address",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV6Addresses: []string{"::1/128"},
+				},
+				{
+					Name:          "eth1",
+					Type:          "physical",
+					MacAddress:    "42:5a:90:c8:24:dc",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"42-5a-90-c8-24-dc",
+		),
+		Entry(
+			"Uses NIC with IPv6 address",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV6Addresses: []string{"5dc8:725d:26ae:1192:d336:54a3:d7c7:23a7/64"},
+				},
+				{
+					Name:          "eth1",
+					Type:          "physical",
+					MacAddress:    "42:5a:90:c8:24:dc",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"71-a0-a4-6f-be-c8",
+		),
+		Entry(
+			"Orders NICs",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:          "b",
+					Type:          "physical",
+					MacAddress:    "42:5a:90:c8:24:dc",
+					IPV4Addresses: []string{"192.168.0.2/24"},
+				},
+				{
+					Name:          "a",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"71-a0-a4-6f-be-c8",
+		),
+		Entry(
+			"Ignores non physical NIC",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "virtual",
+					MacAddress:    "42:5a:90:c8:24:dc",
+					IPV4Addresses: []string{"192.168.0.2/24"},
+				},
+				{
+					Name:          "eth1",
+					Type:          "physical",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV4Addresses: []string{"192.168.0.1/24"},
+				},
+			},
+			"71-a0-a4-6f-be-c8",
+		),
+	)
+})

--- a/src/inventory/main_test.go
+++ b/src/inventory/main_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-installer-agent/src/util"
+	"github.com/sirupsen/logrus"
 )
 
 func newDependenciesMock() *util.MockIDependencies {
@@ -18,7 +19,11 @@ func mockGetGhwChrootRoot(dependencies *util.MockIDependencies) {
 	dependencies.On("GetGhwChrootRoot").Return("/host").Maybe()
 }
 
-func TestSubsystem(t *testing.T) {
+func TestInventory(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Inventory unit tests")
 }
+
+var _ = BeforeSuite(func() {
+	logrus.SetOutput(GinkgoWriter)
+})


### PR DESCRIPTION
Currently hosts that have a forbidden name like `hostname` need to be manually renamed by users before proceeding to the installation of the cluster. That isn't convenient for users. To avoid it this patch changes the code so that the agent will replace those names with automatically generated ones from a MAC address of a network interface card of the host that has a non-local IP address.

Related: https://issues.redhat.com/browse/MGMT-8460