### PR TITLE
MGMT-12711:  Verify that L2 connectivity checks are received grouped by ip+mac instead of just mac

### DIFF
--- a/src/connectivity_check/connectivity_check.go
+++ b/src/connectivity_check/connectivity_check.go
@@ -350,6 +350,10 @@ func (c *connectivity) checkHost(conCheck connectivityCmd, outCh chan models.Con
 		L2Connectivity: []*models.L2Connectivity{},
 		L3Connectivity: []*models.L3Connectivity{},
 	}
+	l2Key := func(c *models.L2Connectivity) string {
+		return c.RemoteIPAddress + c.RemoteMac
+	}
+
 	addresses := getOutgoingAddresses(conCheck.getHost().Nics)
 	dataCh := make(chan any)
 	go c.l3CheckConnectivity(addresses, dataCh, conCheck)
@@ -364,7 +368,7 @@ func (c *connectivity) checkHost(conCheck connectivityCmd, outCh chan models.Con
 		case models.L3Connectivity:
 			ret.L3Connectivity = append(ret.L3Connectivity, &value)
 		case models.L2Connectivity:
-			l2C[value.RemoteMac] = value
+			l2C[l2Key(&value)] = value
 		case done:
 			numDone++
 		}
@@ -375,7 +379,7 @@ func (c *connectivity) checkHost(conCheck connectivityCmd, outCh chan models.Con
 	}
 
 	sort.Slice(ret.L2Connectivity, func(i, j int) bool {
-		return ret.L2Connectivity[i].RemoteMac <= ret.L2Connectivity[j].RemoteMac
+		return l2Key(ret.L2Connectivity[i]) <= l2Key(ret.L2Connectivity[j])
 	})
 
 	outCh <- *ret

--- a/src/connectivity_check/connectivity_check_test.go
+++ b/src/connectivity_check/connectivity_check_test.go
@@ -387,7 +387,7 @@ var _ = Describe("check host parallel validation", func() {
 		l2Conn               []*models.L2Connectivity
 		l3Conn               []*models.L3Connectivity
 		simulateL2IPConflict bool
-		strictMatchingL2       bool
+		strictMatchingL2     bool
 	}{
 		{
 			name:    "Nominal: IPv4 with 2 addresses",
@@ -426,7 +426,7 @@ var _ = Describe("check host parallel validation", func() {
 				},
 			},
 			simulateL2IPConflict: false,
-			strictMatchingL2: false,
+			strictMatchingL2:     false,
 		},
 		{name: "Nominal: IPv6",
 			success: true,
@@ -451,7 +451,7 @@ var _ = Describe("check host parallel validation", func() {
 				},
 			},
 			simulateL2IPConflict: false,
-			strictMatchingL2: false,
+			strictMatchingL2:     false,
 		},
 		{name: "KO: IPv4 unable to connect via ping or arp",
 			success: false,
@@ -472,7 +472,7 @@ var _ = Describe("check host parallel validation", func() {
 				},
 			},
 			simulateL2IPConflict: false,
-			strictMatchingL2: false,
+			strictMatchingL2:     false,
 		},
 		{name: "KO: IPv6 unable to connect via ping or nmap",
 			success: false,
@@ -492,7 +492,7 @@ var _ = Describe("check host parallel validation", func() {
 				},
 			},
 			simulateL2IPConflict: false,
-			strictMatchingL2: false,
+			strictMatchingL2:     false,
 		},
 		{name: "Should correctly report on L2 IP conflicts",
 			success: true,
@@ -523,7 +523,7 @@ var _ = Describe("check host parallel validation", func() {
 				},
 			},
 			simulateL2IPConflict: true,
-			strictMatchingL2: false,
+			strictMatchingL2:     false,
 		},
 		{name: "Should deduplicate L2 entries and ensure consistent order of L2 entries",
 			success: true,
@@ -544,11 +544,34 @@ var _ = Describe("check host parallel validation", func() {
 						Successful:        true,
 						RemoteMac:         "74:d0:2b:1c:c6:42"},
 				},
-				L3Connectivity: []*models.L3Connectivity{
-				},
+				L3Connectivity: []*models.L3Connectivity{},
 			},
 			simulateL2IPConflict: true,
-			strictMatchingL2: true,
+			strictMatchingL2:     true,
+		},
+		{name: "Dual stack",
+			success: true,
+			nics:    []string{"nic"},
+			hosts: &models.ConnectivityCheckHost{Nics: []*models.ConnectivityCheckNic{
+				{IPAddresses: []string{"192.168.1.1", "fe80::d832:8def:dd51:3527"}, Mac: "74:d0:2b:1c:c6:42"},
+			}},
+			expected: &models.ConnectivityRemoteHost{
+				L2Connectivity: []*models.L2Connectivity{
+					{OutgoingNic: "nic",
+						RemoteIPAddress:   "192.168.1.1",
+						OutgoingIPAddress: "192.168.1.133",
+						Successful:        true,
+						RemoteMac:         "74:d0:2b:1c:c6:42"},
+					{OutgoingNic: "nic",
+						RemoteIPAddress:   "fe80::d832:8def:dd51:3527",
+						OutgoingIPAddress: "",
+						Successful:        true,
+						RemoteMac:         "74:d0:2b:1c:c6:42"},
+				},
+				L3Connectivity: []*models.L3Connectivity{},
+			},
+			simulateL2IPConflict: false,
+			strictMatchingL2:     true,
 		},
 	}
 


### PR DESCRIPTION
This will fix the case that only a single result is received if the nic has several addresses.

/cc @tsorya 