### PR TITLE
MGMT-12760: Don't panic when retrying after no response

### DIFF
--- a/src/session/inventory_session.go
+++ b/src/session/inventory_session.go
@@ -153,14 +153,17 @@ func createBmInventoryClient(agentConfig *config.AgentConfig, inventoryUrl strin
 	delayLog := func(delayFn rehttp.DelayFn) rehttp.DelayFn {
 		return func(attempt rehttp.Attempt) time.Duration {
 			delay := delayFn(attempt)
-			logrus.WithFields(logrus.Fields{
+			fields := logrus.Fields{
 				"method":  attempt.Request.Method,
 				"url":     attempt.Request.URL,
-				"status":  attempt.Response.StatusCode,
 				"error":   attempt.Error,
 				"attempt": fmt.Sprintf("%d of %d", attempt.Index+1, retries+1),
 				"delay":   delay,
-			}).Info("Request will be retried")
+			}
+			if attempt.Response != nil {
+				fields["status"] = attempt.Response.StatusCode
+			}
+			logrus.WithFields(fields).Info("Request will be retried")
 			return delay
 		}
 	}


### PR DESCRIPTION
Currently the code that retries requests writes a log message that contains the response status code. But that causes a panic if there is no response, for example if the server didn't respond at all or there was a timeout. This patch fixes that issue.

Related: https://issues.redhat.com/browse/MGMT-12760