### PR TITLE
MGMT-12793: Tang unit tests should not query external URLs

### DIFF
--- a/src/commands/actions/tang_connectivity_check.go
+++ b/src/commands/actions/tang_connectivity_check.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openshift/assisted-installer-agent/src/tang_connectivity_check"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
+	"net/http"
 )
 
 type tangConnectivityCheck struct {
@@ -20,7 +21,8 @@ func (a *tangConnectivityCheck) Validate() error {
 }
 
 func (a *tangConnectivityCheck) Run() (stdout, stderr string, exitCode int) {
-	return tang_connectivity_check.CheckTangConnectivity(a.args[0], logrus.StandardLogger())
+	client := &http.Client{}
+	return tang_connectivity_check.CheckTangConnectivity(a.args[0], logrus.StandardLogger(), client)
 }
 
 func (a *tangConnectivityCheck) Command() string {


### PR DESCRIPTION
The usage of HTTP client should be mocked for tests that use external URLs as a negative flow.

/assign @ori-amizur 