### PR TITLE
MGMT-12827: Don't try to rename when there is no usable NIC

### DIFF
--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -96,6 +96,10 @@ func calculateHostname(inventory *models.Inventory) (result string, err error) {
 	if err != nil {
 		return
 	}
+	if nic == nil {
+		result = inventory.Hostname
+		return
+	}
 	result = strings.ToLower(strings.ReplaceAll(nic.MacAddress, ":", "-"))
 	return
 }

--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -180,5 +180,23 @@ var _ = Describe("Hostname processing", func() {
 			},
 			"71-a0-a4-6f-be-c8",
 		),
+		Entry(
+			"Returns inventory hostname if there is no usable NIC",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:          "eth0",
+					Type:          "virtual",
+					MacAddress:    "42:5a:90:c8:24:dc",
+					IPV4Addresses: []string{"192.168.0.2/24"},
+				},
+				{
+					Name:       "eth1",
+					Type:       "physical",
+					MacAddress: "71:A0:A4:6F:BE:C8",
+				},
+			},
+			"localhost",
+		),
 	)
 })


### PR DESCRIPTION
Currently the code that automatically renames hosts crashes when it can't find a usable NIC. This patch fixes that.

Related: https://issues.redhat.com/browse/MGMT-12827