### PR TITLE
MGMT-12850: Add host id header

### DIFF
--- a/src/commands/service_api.go
+++ b/src/commands/service_api.go
@@ -32,6 +32,7 @@ func (v *v2ServiceAPI) RegisterHost(s *session.InventorySession) (*models.HostRe
 	}
 
 	params := &installer.V2RegisterHostParams{
+		XHostID:               &hostID,
 		InfraEnvID:            strfmt.UUID(v.agentConfig.InfraEnvID),
 		DiscoveryAgentVersion: &v.agentConfig.AgentVersion,
 		NewHostParams: &models.HostCreateParams{
@@ -48,8 +49,10 @@ func (v *v2ServiceAPI) RegisterHost(s *session.InventorySession) (*models.HostRe
 }
 
 func (v *v2ServiceAPI) GetNextSteps(s *session.InventorySession) (*models.Steps, error) {
+	hostID := strfmt.UUID(v.agentConfig.HostID)
 	params := installer.V2GetNextStepsParams{
-		HostID:                strfmt.UUID(v.agentConfig.HostID),
+		XHostID:               &hostID,
+		HostID:                hostID,
 		InfraEnvID:            strfmt.UUID(v.agentConfig.InfraEnvID),
 		DiscoveryAgentVersion: &v.agentConfig.AgentVersion,
 		Timestamp:             swag.Int64(time.Now().Unix()),
@@ -62,8 +65,10 @@ func (v *v2ServiceAPI) GetNextSteps(s *session.InventorySession) (*models.Steps,
 }
 
 func (v *v2ServiceAPI) PostStepReply(s *session.InventorySession, reply *models.StepReply) error {
+	hostID := strfmt.UUID(v.agentConfig.HostID)
 	params := installer.V2PostStepReplyParams{
-		HostID:                strfmt.UUID(v.agentConfig.HostID),
+		XHostID:               &hostID,
+		HostID:                hostID,
 		InfraEnvID:            strfmt.UUID(v.agentConfig.InfraEnvID),
 		DiscoveryAgentVersion: &v.agentConfig.AgentVersion,
 		Reply:                 reply,


### PR DESCRIPTION
This patch changes the agent so that it sends the host identifier in the `X-Host-ID` header. This will be used for rate limiting in the server side.

Related: https://issues.redhat.com/browse/MGMT-12850
Related: https://github.com/openshift/assisted-service/pull/4724