### PR TITLE
MULTIARCH-3239 -- Add multipath FC disk check for Power

### DIFF
--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -179,7 +179,7 @@ func isISCSIDisk(disk *ghw.Disk) bool {
 }
 
 func isFCDisk(disk *ghw.Disk) bool {
-	return strings.Contains(disk.BusPath, "-fc-")
+	return strings.Contains(disk.BusPath, "-fc-") || strings.HasPrefix(disk.BusPath, "fc-")
 }
 
 func (d *disks) dmUUIDHasPrefix(disk *ghw.Disk, prefix string) bool {


### PR DESCRIPTION
Add multipath FC disk check to enable RHCOS installation for PowerVM with SAN disk.

Signed-off-by: CS Zhang <zhangcho@us.ibm.com>