### PR TITLE
Make the agent team be the OWNERS of the Dockerfile.ocp file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,9 @@ filters:
       - emeritus_approvers
     reviewers:
       - approvers
-  ^Dockerfile\..*:
+  ^Dockerfile\.(?!ocp).*:
     labels:
       - downstream-change-needed
+  ^Dockerfile\.ocp:
+    approvers:
+      - agent_team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,3 +27,9 @@ aliases:
     - yevgeny-shnaidman
     - lranjbar
     - ybettan
+  agent_team:
+    - andfasano
+    - bfournie
+    - pawanpinjarkar
+    - rwsu
+    - zaneb


### PR DESCRIPTION
Also there's no "downstream" for this Dockerfile so that label is
unnecessary