### PR TITLE
MGMT-13758: In connectivity check, ARPING checks should not run on nics without valid IPv4 address

### DIFF
--- a/src/connectivity_check/connectivity_check_test.go
+++ b/src/connectivity_check/connectivity_check_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/assisted-installer-agent/src/util"
 	"github.com/openshift/assisted-service/models"
 	log "github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
 )
 
 var _ = Describe("check host parallel validation", func() {
@@ -216,7 +217,9 @@ var _ = Describe("check host parallel validation", func() {
 		t := tests[i]
 		It(t.name, func() {
 			d := setupDispather(t.simulateL2IPConflict, t.success, t.hosts.Nics)
-			ret, err := d.Run(models.ConnectivityCheckParams{t.hosts}, t.nics)
+			ret, err := d.Run(models.ConnectivityCheckParams{t.hosts}, funk.Map(t.nics, func(s string) OutgoingNic {
+				return OutgoingNic{Name: s, HasIpv4Addresses: true, HasIpv6Addresses: true}
+			}).([]OutgoingNic))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret.RemoteHosts).To(HaveLen(1))
 			if !t.strictMatchingL2 {

--- a/src/connectivity_check/connectivity_runner.go
+++ b/src/connectivity_check/connectivity_runner.go
@@ -17,6 +17,12 @@ const (
 	RemoteMACFeature
 )
 
+type OutgoingNic struct {
+	Name             string
+	HasIpv4Addresses bool
+	HasIpv6Addresses bool
+}
+
 // Attributes to be sent to a checker in order to perform a single checking operation
 type Attributes struct {
 	// The IP address of the remote host to check
@@ -26,7 +32,7 @@ type Attributes struct {
 	RemoteMACAddress string
 
 	// Request to perform the test on a specific outgoing (local) NIC
-	OutgoingNIC string
+	OutgoingNIC OutgoingNic
 
 	// All the MAC addresses of the remote host
 	RemoteMACAddresses []string
@@ -76,7 +82,7 @@ func spawnChecker(attributes Attributes, reporterChan chan ResultReporter, wg *s
 	}
 }
 
-func (d *connectivityRunner) ProcessHost(checkHost *models.ConnectivityCheckHost, outgoingNics []string, resultChan chan checkedHostResult) {
+func (d *connectivityRunner) ProcessHost(checkHost *models.ConnectivityCheckHost, outgoingNics []OutgoingNic, resultChan chan checkedHostResult) {
 	var (
 		resultingHost models.ConnectivityRemoteHost
 		wg            sync.WaitGroup
@@ -129,7 +135,7 @@ func (d *connectivityRunner) ProcessHost(checkHost *models.ConnectivityCheckHost
 	funk.ForEach(d.checkers, func(c Checker) { c.Finalize(&resultingHost) })
 }
 
-func (d *connectivityRunner) Run(params models.ConnectivityCheckParams, outgoingNics []string) (models.ConnectivityReport, error) {
+func (d *connectivityRunner) Run(params models.ConnectivityCheckParams, outgoingNics []OutgoingNic) (models.ConnectivityReport, error) {
 	var (
 		ret models.ConnectivityReport
 		err error

--- a/src/connectivity_check/connectivity_runner_test.go
+++ b/src/connectivity_check/connectivity_runner_test.go
@@ -14,13 +14,17 @@ var _ = Describe("connectivity dispatcher", func() {
 	var (
 		mockCheckers []*MockChecker
 		mockReporter *MockResultReporter
-		nics         []string
+		nics         []OutgoingNic
 		params       models.ConnectivityCheckParams
 	)
 	BeforeEach(func() {
-		nics = []string{
-			"eth0",
-			"eth1",
+		nics = []OutgoingNic{
+			{
+				Name: "eth0",
+			},
+			{
+				Name: "eth1",
+			},
 		}
 		params = models.ConnectivityCheckParams{
 			{
@@ -95,7 +99,7 @@ var _ = Describe("connectivity dispatcher", func() {
 			Run(func(args mock.Arguments) {
 				attributes, ok := args.Get(0).(Attributes)
 				Expect(ok).To(BeTrue())
-				Expect(attributes.OutgoingNIC).To(BeEmpty())
+				Expect(attributes.OutgoingNIC).To(Equal(OutgoingNic{}))
 				Expect(attributes.RemoteIPAddress).To(BeElementOf([]string{"10.1.2.3", "10.1.2.4", "de::1", "de::2"}))
 				Expect(attributes.RemoteMACAddress).To(BeElementOf([]string{"f8:75:a4:a4:00:fe", "f8:75:a4:a4:00:ff"}))
 				Expect(attributes.RemoteMACAddresses).To(ConsistOf([]string{"f8:75:a4:a4:00:fe", "f8:75:a4:a4:00:ff"}))
@@ -124,7 +128,7 @@ var _ = Describe("connectivity dispatcher", func() {
 			Run(func(args mock.Arguments) {
 				attributes, ok := args.Get(0).(Attributes)
 				Expect(ok).To(BeTrue())
-				Expect(attributes.OutgoingNIC).To(BeElementOf([]string{"eth0", "eth1"}))
+				Expect(attributes.OutgoingNIC.Name).To(BeElementOf([]string{"eth0", "eth1"}))
 				Expect(attributes.RemoteIPAddress).To(BeElementOf([]string{"10.1.2.3", "10.1.2.4", "de::1", "de::2"}))
 				Expect(attributes.RemoteMACAddress).To(BeElementOf([]string{"f8:75:a4:a4:00:fe", "f8:75:a4:a4:00:ff"}))
 				Expect(attributes.RemoteMACAddresses).To(ConsistOf([]string{"f8:75:a4:a4:00:fe", "f8:75:a4:a4:00:ff"}))

--- a/src/connectivity_check/dry_run_checkers.go
+++ b/src/connectivity_check/dry_run_checkers.go
@@ -14,7 +14,7 @@ func (d *dryL2Checker) Features() Features {
 
 func (d *dryL2Checker) Check(attributes Attributes) ResultReporter {
 	return newL2ResultReporter(&models.L2Connectivity{
-		OutgoingNic:     attributes.OutgoingNIC,
+		OutgoingNic:     attributes.OutgoingNIC.Name,
 		RemoteIPAddress: attributes.RemoteIPAddress,
 		RemoteMac:       attributes.RemoteMACAddress,
 		Successful:      true,

--- a/src/connectivity_check/ipv4_arping_checker_test.go
+++ b/src/connectivity_check/ipv4_arping_checker_test.go
@@ -55,7 +55,7 @@ Received 0 response(s)
 		attributes := Attributes{
 			RemoteIPAddress:    remoteIPAddress,
 			RemoteMACAddress:   remoteMACAddress,
-			OutgoingNIC:        outgoingNIC,
+			OutgoingNIC:        OutgoingNic{Name: outgoingNIC, HasIpv4Addresses: true},
 			RemoteMACAddresses: remoteMACAddresses,
 		}
 		mockFullReply(remoteIPAddress, remoteMACAddress)
@@ -70,11 +70,21 @@ Received 0 response(s)
 		Expect(resultingHost.L2Connectivity[0].OutgoingIPAddress).To(Equal(outgoingIPAddress))
 		Expect(resultingHost.L2Connectivity[0].Successful).To(BeTrue())
 	})
+	It("no ipv4 addresses", func() {
+		attributes := Attributes{
+			RemoteIPAddress:    remoteIPAddress,
+			RemoteMACAddress:   remoteMACAddress,
+			OutgoingNIC:        OutgoingNic{Name: outgoingNIC, HasIpv6Addresses: true},
+			RemoteMACAddresses: remoteMACAddresses,
+		}
+		reporter := checker.Check(attributes)
+		Expect(reporter).To(BeNil())
+	})
 	It("happy flow with secondary mac", func() {
 		attributes := Attributes{
 			RemoteIPAddress:    remoteIPAddress,
 			RemoteMACAddress:   remoteMACAddress,
-			OutgoingNIC:        outgoingNIC,
+			OutgoingNIC:        OutgoingNic{Name: outgoingNIC, HasIpv4Addresses: true},
 			RemoteMACAddresses: remoteMACAddresses,
 		}
 		mockFullReply(remoteIPAddress, secondaryMACAddress)
@@ -93,7 +103,7 @@ Received 0 response(s)
 		attributes := Attributes{
 			RemoteIPAddress:    remoteIPAddress,
 			RemoteMACAddress:   remoteMACAddress,
-			OutgoingNIC:        outgoingNIC,
+			OutgoingNIC:        OutgoingNic{Name: outgoingNIC, HasIpv4Addresses: true},
 			RemoteMACAddresses: remoteMACAddresses,
 		}
 		mockFullReply(remoteIPAddress, additionalMACAddress)
@@ -112,7 +122,7 @@ Received 0 response(s)
 		attributes := Attributes{
 			RemoteIPAddress:    remoteIPAddress,
 			RemoteMACAddress:   remoteMACAddress,
-			OutgoingNIC:        outgoingNIC,
+			OutgoingNIC:        OutgoingNic{Name: outgoingNIC, HasIpv4Addresses: true},
 			RemoteMACAddresses: remoteMACAddresses,
 		}
 		mockEmptyReply(remoteIPAddress)

--- a/src/connectivity_check/util_test.go
+++ b/src/connectivity_check/util_test.go
@@ -1,0 +1,63 @@
+package connectivity_check
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-installer-agent/src/util"
+)
+
+var _ = Describe("get outgoing nics", func() {
+	var (
+		d *util.MockIDependencies
+	)
+
+	BeforeEach(func() {
+		d = &util.MockIDependencies{}
+	})
+
+	AfterEach(func() {
+		d.AssertExpectations(GinkgoT())
+	})
+
+	It("ipv4", func() {
+		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{"1.2.3.4/24"},
+			100, "physical")}, nil)
+		outgoingNics := getOutgoingNics(nil, d)
+		Expect(outgoingNics).To(HaveLen(1))
+		Expect(outgoingNics[0]).To(Equal(OutgoingNic{Name: "eth0", HasIpv4Addresses: true}))
+	})
+	It("ipv6", func() {
+		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{"2003::10/64"},
+			100, "physical")}, nil)
+		outgoingNics := getOutgoingNics(nil, d)
+		Expect(outgoingNics).To(HaveLen(1))
+		Expect(outgoingNics[0]).To(Equal(OutgoingNic{Name: "eth0", HasIpv6Addresses: true}))
+	})
+	It("dual stack", func() {
+		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{"1.2.3.4/24",
+			"2003::10/64"}, 100, "physical")}, nil)
+		outgoingNics := getOutgoingNics(nil, d)
+		Expect(outgoingNics).To(HaveLen(1))
+		Expect(outgoingNics[0]).To(Equal(OutgoingNic{Name: "eth0", HasIpv4Addresses: true, HasIpv6Addresses: true}))
+	})
+	It("ipv4 link local", func() {
+		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{"169.254.0.5/16"},
+			100, "physical")}, nil)
+		outgoingNics := getOutgoingNics(nil, d)
+		Expect(outgoingNics).To(BeEmpty())
+	})
+	It("ipv6 link local", func() {
+		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{"fe80::f/10"},
+			100, "physical")}, nil)
+		outgoingNics := getOutgoingNics(nil, d)
+		Expect(outgoingNics).To(BeEmpty())
+	})
+	It("no addressexs", func() {
+		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{},
+			100, "physical")}, nil)
+		outgoingNics := getOutgoingNics(nil, d)
+		Expect(outgoingNics).To(BeEmpty())
+	})
+})


### PR DESCRIPTION

When check L2 IPv4 with ARPING, testing on interfaces that do not have valid IPv4 addresses causes the arp table to have duplicate entries, which may cause troubles in connectivity checks and packet losses. This change ensures that only interfaces with valid addresses are used for L2 check.
In addition, same restriction is applied when doing IPv6 L2 check.

/cc @filanov 