### PR TITLE
OCPBUGS-8490: vendor agent-installer-utils to v0.0.0-20230307094740-57807526b660 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.1
-	github.com/openshift/agent-installer-utils v0.0.0-20230301211343-99aefff106c7
+	github.com/openshift/agent-installer-utils v0.0.0-20230307094740-57807526b660
 	github.com/openshift/assisted-service v1.0.10-0.20221227183914-58b7b4b0fd8e
 	github.com/openshift/assisted-service/models v0.0.0
 	github.com/openshift/baremetal-runtimecfg v0.0.0-20220211165258-fe92b9507bec

--- a/go.sum
+++ b/go.sum
@@ -1065,14 +1065,8 @@ github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xA
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/openshift-online/ocm-sdk-go v0.1.205 h1:DhvfTf55jpQsTFpI283/z3b0Tab8x26oelPDuao7IiM=
 github.com/openshift-online/ocm-sdk-go v0.1.205/go.mod h1:iOhkt/6nFp9v7hasdmGbYlR/YKeUoaZKq5ZBrtyKwKg=
-github.com/openshift/agent-installer-utils v0.0.0-20230223084712-2eb1d99104de h1:d/aaV2vHyHtuQxS+6Y2kc4iTv8KTMoEWu/6qi5LAy8k=
-github.com/openshift/agent-installer-utils v0.0.0-20230223084712-2eb1d99104de/go.mod h1:NQY4g4PCOiK/M3p/N1iJHDk8snbISaLHBRgKeCJW73Y=
-github.com/openshift/agent-installer-utils v0.0.0-20230227172155-0e307b16d36b h1:SuLe4DxylTXm7aBQ5YbvD8Y23TBM4RIyEFyBTtaCP/k=
-github.com/openshift/agent-installer-utils v0.0.0-20230227172155-0e307b16d36b/go.mod h1:NQY4g4PCOiK/M3p/N1iJHDk8snbISaLHBRgKeCJW73Y=
-github.com/openshift/agent-installer-utils v0.0.0-20230228190135-5b30a39dadf6 h1:GY9e9VLrxkrTKlymL0gj5fX4cUfeHNT1LvAqyMRH+gs=
-github.com/openshift/agent-installer-utils v0.0.0-20230228190135-5b30a39dadf6/go.mod h1:NQY4g4PCOiK/M3p/N1iJHDk8snbISaLHBRgKeCJW73Y=
-github.com/openshift/agent-installer-utils v0.0.0-20230301211343-99aefff106c7 h1:0TaVjqFs9gAo/tMVVi8tJOneYwPnL4M+pU6Hqad9rSY=
-github.com/openshift/agent-installer-utils v0.0.0-20230301211343-99aefff106c7/go.mod h1:NQY4g4PCOiK/M3p/N1iJHDk8snbISaLHBRgKeCJW73Y=
+github.com/openshift/agent-installer-utils v0.0.0-20230307094740-57807526b660 h1:RiDskVQrPeKOIaEOUuJpy+L77EQf0P683trLJV8pD/Y=
+github.com/openshift/agent-installer-utils v0.0.0-20230307094740-57807526b660/go.mod h1:NQY4g4PCOiK/M3p/N1iJHDk8snbISaLHBRgKeCJW73Y=
 github.com/openshift/assisted-service v1.0.10-0.20221227183914-58b7b4b0fd8e h1:5Iebch6U5GGT++Xy3o5EFDm/P7ym0BOzQKrkqcFHCQs=
 github.com/openshift/assisted-service v1.0.10-0.20221227183914-58b7b4b0fd8e/go.mod h1:dvRhb37B13cwo3jDDUl/PNSAiIr8WKhywP/3cIAxJPo=
 github.com/openshift/assisted-service/models v0.0.0-20221227183914-58b7b4b0fd8e h1:10vOkWKegftWJRiuHRIC/U/3ucaaa4m+7i9gvXUnwzw=

--- a/vendor/github.com/openshift/agent-installer-utils/tools/agent_tui/ui/check_page.go
+++ b/vendor/github.com/openshift/agent-installer-utils/tools/agent_tui/ui/check_page.go
@@ -16,6 +16,9 @@ const (
 	CONFIGURE_BUTTON        string = "<Configure network>"
 	QUIT_BUTTON             string = "<Quit>"
 	PAGE_CHECKSCREEN        string = "checkScreen"
+
+	mainFlexHeight            = 10
+	mainFlexWithDetailsHeight = 30
 )
 
 func (u *UI) SetPullCheck(cr checks.CheckResult) {
@@ -164,32 +167,52 @@ func (u *UI) createCheckPage(config checks.Config) {
 		return
 	})
 
-	// SetRows(number-of-lines-to-give-1st-row,
-	//         number-of-lines-to-give-2nd-row,..etc)
-	// 0 means fill
-	u.grid = tview.NewGrid().SetRows(5, 6, 0, 3).SetColumns(0).
-		AddItem(u.primaryCheck, 0, 0, 1, 1, 0, 0, false).
-		AddItem(u.checks, 1, 0, 1, 1, 0, 0, false).
-		AddItem(u.details, 2, 0, 1, 1, 0, 0, false).
-		AddItem(u.form, 3, 0, 1, 1, 0, 0, false)
-	u.grid.SetTitle("  Agent installer network boot setup  ")
-	u.grid.SetTitleColor(newt.ColorRed)
-	u.grid.SetBorder(true)
-	u.grid.SetBackgroundColor(newt.ColorGray)
-	u.grid.SetBorderColor(tcell.ColorBlack)
+	u.mainFlex = tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(u.primaryCheck, 5, 0, false).
+		AddItem(u.form, 3, 0, false)
+	u.mainFlex.SetTitle("  Agent installer network boot setup  ").
+		SetTitleColor(newt.ColorRed).
+		SetBorder(true).
+		SetBackgroundColor(newt.ColorGray).
+		SetBorderColor(tcell.ColorBlack)
+
+	u.innerFlex = tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(nil, 0, 1, false).
+		AddItem(u.mainFlex, mainFlexHeight, 0, false).
+		AddItem(nil, 0, 1, false)
 
 	width := 80
 	flex := tview.NewFlex().
 		AddItem(nil, 0, 1, false).
-		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
-			AddItem(nil, 0, 1, false).
-			AddItem(u.grid, 0, 8, true).
-			AddItem(nil, 0, 1, false), width, 1, true).
+		AddItem(u.innerFlex, width, 1, false).
 		AddItem(nil, 0, 1, false)
 
 	u.pages.SetBackgroundColor(newt.ColorBlue)
-
 	u.pages.AddPage(PAGE_CHECKSCREEN, flex, true, true)
-
 	u.app.SetRoot(u.pages, true).SetFocus(u.form)
+}
+
+func (u *UI) HideAdditionalChecks() {
+	if u.mainFlex.GetItemCount() <= 2 {
+		return
+	}
+
+	u.mainFlex.
+		RemoveItem(u.checks).
+		RemoveItem(u.details)
+	u.innerFlex.ResizeItem(u.mainFlex, mainFlexHeight, 0)
+}
+
+func (u *UI) ShowAdditionalChecks() {
+	if u.mainFlex.GetItemCount() > 2 {
+		return
+	}
+
+	u.mainFlex.
+		RemoveItem(u.form).
+		AddItem(u.checks, 5, 0, false).
+		AddItem(u.details, 15, 0, false).
+		AddItem(u.form, 3, 0, false)
+	u.innerFlex.ResizeItem(u.mainFlex, mainFlexWithDetailsHeight, 0)
 }

--- a/vendor/github.com/openshift/agent-installer-utils/tools/agent_tui/ui/ui.go
+++ b/vendor/github.com/openshift/agent-installer-utils/tools/agent_tui/ui/ui.go
@@ -10,7 +10,7 @@ import (
 type UI struct {
 	app                 *tview.Application
 	pages               *tview.Pages
-	grid                *tview.Grid // layout for the checks page
+	mainFlex, innerFlex *tview.Flex
 	primaryCheck        *tview.Table
 	checks              *tview.Table    // summary of all checks
 	details             *tview.TextView // where errors from checks are displayed

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -480,7 +480,7 @@ github.com/openshift-online/ocm-sdk-go/metrics
 github.com/openshift-online/ocm-sdk-go/retry
 github.com/openshift-online/ocm-sdk-go/servicelogs
 github.com/openshift-online/ocm-sdk-go/servicelogs/v1
-# github.com/openshift/agent-installer-utils v0.0.0-20230301211343-99aefff106c7
+# github.com/openshift/agent-installer-utils v0.0.0-20230307094740-57807526b660
 ## explicit; go 1.18
 github.com/openshift/agent-installer-utils/tools/agent_tui
 github.com/openshift/agent-installer-utils/tools/agent_tui/checks


### PR DESCRIPTION
This patch is a cherry-pick from https://github.com/openshift/assisted-installer-agent/pull/512 for the release 4.13