### PR TITLE
MGMT-13946: Ignore Proliant Gen 11 serial

### DIFF
--- a/src/scanners/machine_uuid_scanner.go
+++ b/src/scanners/machine_uuid_scanner.go
@@ -23,6 +23,7 @@ const (
 	SerialUnspecifiedBaseBoardString = "unspecified base board serial number" // BF cards
 	SerialUnspecifiedSystemString    = "unspecified system serial number"     // BF cards
 	SerialNotSpecified               = "not specified"                        // Linode
+	SerialProliantGen11              = "PCA_number.ACC"                       // Proliant Gen 11
 	ZeroesUUID                       = "00000000-0000-0000-0000-000000000000"
 	KaloomUUID                       = "03000200-0400-0500-0006-000700080009" // All hosts of this type have the same UUID
 )
@@ -33,7 +34,7 @@ var (
 
 var unknownSerialCases = []string{"", util.UNKNOWN, "none",
 	SerialUnspecifiedBaseBoardString, SerialUnspecifiedSystemString,
-	SerialDefaultString, SerialNotSpecified}
+	SerialDefaultString, SerialNotSpecified, strings.ToLower(SerialProliantGen11)}
 var unknownUuidCases = []string{"", util.UNKNOWN, ZeroesUUID, KaloomUUID}
 
 func disableGHWWarnings() {

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Machine uuid test", func() {
 		uuid     string
 	}{
 		{useCase: "kaloom", mbSerial: SerialDefaultString, uuid: KaloomUUID},
+		{useCase: "proliantgen11", mbSerial: SerialProliantGen11, uuid: ZeroesUUID},
 		{useCase: "zeroes", mbSerial: SerialDefaultString, uuid: ZeroesUUID},
 		{useCase: "linode", mbSerial: SerialNotSpecified, uuid: "Not Settable"},
 	}


### PR DESCRIPTION
We have seen different hosts with the same motherboard serial on this type of hardware, so we should ignore it and fallback to other methods of generating the host UUID.