### PR TITLE
Force update to pick up latest libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ To run selected system tests use a [regular expression](https://onsi.github.io/g
 
 To publish the container image run `skipper make push`.
 You can override the image name and tag via the `ASSISTED_INSTALLER_AGENT` variable.
+


### PR DESCRIPTION
The libnmstate library has been updated from .1 to .2 (see https://issues.redhat.com/browse/ART-6481). This is used by agent-tui. Force an rebuild with a trivial change in order to pick up the updated lib.