### PR TITLE
MGMT-14481: journal logs are empty during installation on rhel9.2

### DIFF
--- a/src/logs_sender/mock_LogsSender.go
+++ b/src/logs_sender/mock_LogsSender.go
@@ -124,6 +124,34 @@ func (_m *MockLogsSender) ExecutePrivileged(command string, args ...string) (str
 	return r0, r1, r2
 }
 
+// ExecutePrivilegedToFile provides a mock function with given fields: outputFilePath, command, args
+func (_m *MockLogsSender) ExecutePrivilegedToFile(outputFilePath string, command string, args ...string) (string, int) {
+	_va := make([]interface{}, len(args))
+	for _i := range args {
+		_va[_i] = args[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, outputFilePath, command)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string, ...string) string); ok {
+		r0 = rf(outputFilePath, command, args...)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 int
+	if rf, ok := ret.Get(1).(func(string, string, ...string) int); ok {
+		r1 = rf(outputFilePath, command, args...)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	return r0, r1
+}
+
 // FileUploader provides a mock function with given fields: filePath
 func (_m *MockLogsSender) FileUploader(filePath string) error {
 	ret := _m.Called(filePath)

--- a/src/logs_sender/send_logs.go
+++ b/src/logs_sender/send_logs.go
@@ -42,6 +42,7 @@ type LogsSender interface {
 	Execute(command string, args ...string) (stdout string, stderr string, exitCode int)
 	ExecutePrivileged(command string, args ...string) (stdout string, stderr string, exitCode int)
 	ExecuteOutputToFile(outputFilePath string, command string, args ...string) (stderr string, exitCode int)
+	ExecutePrivilegedToFile(outputFilePath string, command string, args ...string) (stderr string, exitCode int)
 	CreateFolderIfNotExist(folder string) error
 	FileUploader(filePath string) error
 	LogProgressReport(progress models.LogsState) error
@@ -77,6 +78,10 @@ func (e *LogsSenderExecuter) ExecutePrivileged(command string, args ...string) (
 
 func (e *LogsSenderExecuter) ExecuteOutputToFile(outputFilePath string, command string, args ...string) (stderr string, exitCode int) {
 	return util.ExecuteOutputToFile(outputFilePath, command, args...)
+}
+
+func (e *LogsSenderExecuter) ExecutePrivilegedToFile(outputFilePath string, command string, args ...string) (stderr string, exitCode int) {
+	return util.ExecutePrivilegedToFile(outputFilePath, command, args...)
 }
 
 func (e *LogsSenderExecuter) CreateFolderIfNotExist(folder string) error {
@@ -314,7 +319,7 @@ func getJournalLogs(l LogsSender, since string, outputFilePath string, journalFi
 	}
 
 	args = append(args, journalFilterParams...)
-	stderr, exitCode := l.ExecuteOutputToFile(outputFilePath, "journalctl", args...)
+	stderr, exitCode := l.ExecutePrivilegedToFile(outputFilePath, "journalctl", args...)
 	if exitCode != 0 {
 		err := errors.Errorf(stderr)
 		log.WithError(err).Errorf("Failed to run journalctl command")

--- a/src/logs_sender/send_logs_test.go
+++ b/src/logs_sender/send_logs_test.go
@@ -52,13 +52,13 @@ var _ = Describe("logs sender", func() {
 	executeOutputToFileSuccess := func(retVal int) {
 		for _, tag := range loggingConfig.Tags {
 			outputPath := path.Join(logsTmpFilesDir, fmt.Sprintf("%s.logs", tag))
-			logsSenderMock.On("ExecuteOutputToFile", outputPath, "journalctl", "-D", "/var/log/journal/", "--all",
+			logsSenderMock.On("ExecutePrivilegedToFile", outputPath, "journalctl", "-D", "/var/log/journal/", "--all",
 				"--since", loggingConfig.Since, fmt.Sprintf("TAG=%s", tag)).
 				Return("Dummy", retVal)
 		}
 		for _, service := range loggingConfig.Services {
 			outputPath := path.Join(logsTmpFilesDir, fmt.Sprintf("%s.logs", service))
-			logsSenderMock.On("ExecuteOutputToFile", outputPath, "journalctl", "-D", "/var/log/journal/", "--all",
+			logsSenderMock.On("ExecutePrivilegedToFile", outputPath, "journalctl", "-D", "/var/log/journal/", "--all",
 				"--since", loggingConfig.Since, "-u", service).
 				Return("Dummy", retVal)
 		}
@@ -190,7 +190,7 @@ var _ = Describe("logs sender", func() {
 
 	It("journal logs with since", func() {
 		outputPath := path.Join(logsTmpFilesDir, "journal.logs")
-		logsSenderMock.On("ExecuteOutputToFile", outputPath, "journalctl", "-D", "/var/log/journal/", "--all",
+		logsSenderMock.On("ExecutePrivilegedToFile", outputPath, "journalctl", "-D", "/var/log/journal/", "--all",
 			"--since", loggingConfig.Since).Return("Dummy", 0)
 		err := getJournalLogs(logsSenderMock, loggingConfig.Since, outputPath, []string{})
 		Expect(err).NotTo(HaveOccurred())
@@ -199,7 +199,7 @@ var _ = Describe("logs sender", func() {
 	It("full journal logs", func() {
 		outputPath := path.Join(logsTmpFilesDir, "journal.logs")
 		loggingConfig.Since = ""
-		logsSenderMock.On("ExecuteOutputToFile", outputPath, "journalctl", "-D", "/var/log/journal/",
+		logsSenderMock.On("ExecutePrivilegedToFile", outputPath, "journalctl", "-D", "/var/log/journal/",
 			"--all").Return("Dummy", 0)
 		err := getJournalLogs(logsSenderMock, loggingConfig.Since, outputPath, []string{})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
[MGMT-14481](https://issues.redhat.com//browse/MGMT-14481): journal logs are empty during installation on rhel9.2
Running journal logs gathering on host and not inside container