### PR TITLE
MGMT-14384: Set restricted list of approvers for the new branch

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,34 +2,7 @@
 
 aliases:
   approvers:
-    - avishayt
-    - eranco74
+    - romfreiman
     - filanov
     - gamli75
-    - ori-amizur
-    - romfreiman
-    - tsorya
-    - nmagnezi
-    - carbonin
-    - danielerez
-    - slaviered
     - osherdp
-    - omertuc
-    - mkowalski
-    - eliorerz
-    - flaper87
-    - paul-maidment
-    - rccrdpccl
-    - jhernand
-    - vrutkovs
-  emeritus_approvers:
-    - empovit
-    - yevgeny-shnaidman
-    - lranjbar
-    - ybettan
-  agent_team:
-    - andfasano
-    - bfournie
-    - pawanpinjarkar
-    - rwsu
-    - zaneb


### PR DESCRIPTION
Since there are (currently) no label restrictions on attached Jira bugs, we don't have a good way to enforce people are only merging bug-fixes / security-patches.
Setting a smaller approvers list can help us enforce this kind of restriction (list might change later on, if needed)

/cc @filanov @gamli75 @romfreiman