### PR TITLE
MGMT-13009: Auto rename host with VLAN

### DIFF
--- a/src/inventory/inventory.go
+++ b/src/inventory/inventory.go
@@ -119,6 +119,7 @@ func findUsableNIC(inventory *models.Inventory) (result *models.Interface, err e
 	// Find the first NIC that has a MAC address an a global IP address:
 	for _, nic := range nics {
 		isPhysical := nic.Type == "physical"
+		isVLAN := nic.Type == "vlan"
 		hasMAC := nic.MacAddress != ""
 		hasV4 := false
 		for _, ip := range nic.IPV4Addresses {
@@ -140,7 +141,7 @@ func findUsableNIC(inventory *models.Inventory) (result *models.Interface, err e
 				break
 			}
 		}
-		if isPhysical && hasMAC && (hasV4 || hasV6) {
+		if (isPhysical || isVLAN) && hasMAC && (hasV4 || hasV6) {
 			result = nic
 			return
 		}

--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -198,5 +198,23 @@ var _ = Describe("Hostname processing", func() {
 			},
 			"localhost",
 		),
+		Entry(
+			"Renames with VLAN",
+			"localhost",
+			[]*models.Interface{
+				{
+					Name:       "eth0",
+					Type:       "physical",
+					MacAddress: "71:A0:A4:6F:BE:C8",
+				},
+				{
+					Name:          "eth0.42",
+					Type:          "vlan",
+					MacAddress:    "71:A0:A4:6F:BE:C8",
+					IPV4Addresses: []string{"192.168.0.2/24"},
+				},
+			},
+			"71-a0-a4-6f-be-c8",
+		),
 	)
 })


### PR DESCRIPTION
Currently the host auto rename feature doesn't work for hosts that only have IP addresses in VLAN network interface cards. This patch fixes that limitation.

Related: https://issues.redhat.com/browse/MGMT-13009