### PR TITLE
MGMT-14540: Mark Appliance disk(s) with a partition name prefix 'agent' as eligible

### DIFF
--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -16,6 +16,8 @@ import (
 	"github.com/thoas/go-funk"
 )
 
+const applianceAgentPartitionNamePrefix = "agent"
+
 type disks struct {
 	dependencies     util.IDependencies
 	subprocessConfig *config.SubprocessConfig
@@ -257,6 +259,13 @@ func (d *disks) checkEligibility(disk *ghw.Disk) (notEligibleReasons []string, i
 
 	if d.isLVM(disk) {
 		notEligibleReasons = append(notEligibleReasons, "Disk is an LVM logical volume")
+	}
+
+	// Don't check partitions if this is an appliance disk, as those disks should be marked as eligible for installation.
+	for _, partition := range disk.Partitions {
+		if strings.HasPrefix(partition.Label, applianceAgentPartitionNamePrefix) {
+			return notEligibleReasons, false
+		}
 	}
 
 	// Check disk partitions for type, name, and mount points:

--- a/src/inventory/disks_test.go
+++ b/src/inventory/disks_test.go
@@ -573,6 +573,51 @@ var _ = Describe("Disks test", func() {
 		Expect(ret).To(Equal(expectedDisks))
 	})
 
+	It("Allows appliance disk", func() {
+		disksAmount := 4
+		regularDiskIndex := 3
+
+		partitionNameSuffix := [...]string{"boot", "data", "foo", "bar"}
+
+		blockInfo, expectedDisks := prepareDisksTest(dependencies, disksAmount)
+
+		for i := 0; i < disksAmount; i++ {
+			if i == regularDiskIndex {
+				// Make sure regular disks don't get marked as installation media
+				expectedDisks[i].InstallationEligibility.Eligible = true
+				expectedDisks[i].IsInstallationMedia = false
+				continue
+			}
+			blockInfo.Disks[i].Partitions = []*ghw.Partition{
+				{
+					Disk:       nil,
+					Name:       "partition1",
+					Label:      "partition1-label",
+					MountPoint: "/media/iso",
+					SizeBytes:  5555,
+					Type:       "ext4",
+					IsReadOnly: false,
+				},
+				{
+					Disk:       nil,
+					Name:       "partition2",
+					Label:      fmt.Sprintf("%s%s",applianceAgentPartitionNamePrefix, partitionNameSuffix[i]),
+					MountPoint: "",
+					SizeBytes:  5555,
+					Type:       "ext4",
+					IsReadOnly: false,
+				},
+			}
+			expectedDisks[i].InstallationEligibility.Eligible = true
+			expectedDisks[i].InstallationEligibility.NotEligibleReasons = nil
+			expectedDisks[i].IsInstallationMedia = false
+		}
+
+		mockFetchDisks(dependencies, nil, blockInfo.Disks...)
+		ret := GetDisks(&config.SubprocessConfig{}, dependencies)
+		Expect(ret).To(Equal(expectedDisks))
+	})
+
 	It("ODD marked as installation media, HDD is not", func() {
 		blockInfo, expectedDisks := prepareDisksTest(dependencies, 2)
 


### PR DESCRIPTION
This change modifies the disk `checkEligibility` function to take [openshift-appliance](https://github.com/openshift/appliance)
disks into account.

In a case where the disks have partitions with the `'agent'` prefix, those disks
should be marked as eligible for installation. This is a change from the existing
behavior, that used to mark disks with mounted partitions as not eligible
for installation.

[openshift-appliance](https://github.com/openshift/appliance) is a command line utility for building a disk image that
orchestrates OpenShift installation using the Agent-based installer, mainly
with disconnected environments in mind.

Co-authored-by: Avishay Traeger <atraeger@redhat.com>