### PR TITLE
MGMT-13111: Retry get next steps for ever

### DIFF
--- a/src/commands/step_processor.go
+++ b/src/commands/step_processor.go
@@ -296,7 +296,12 @@ func ProcessSteps(ctx context.Context, cancel context.CancelFunc, agentConfig *c
 		log.Errorf("Step processing failed, will try again in %s: %v", delay, err)
 	}
 	for !exit {
+		// Note that this back-off configuration, with the max elapsed time set to zero,
+		// means that there is no limit; after reaching the five minute interval we will
+		// keep retrying every five minutes for ever.
 		backOff := backoff.NewExponentialBackOff()
+		backOff.MaxInterval = 5 * time.Minute
+		backOff.MaxElapsedTime = 0
 		err := backoff.RetryNotify(operation, backOff, notify)
 		if err != nil {
 			log.Errorf("Step processing failed, will exit: %v", err)


### PR DESCRIPTION
Currently when the request to get next steps fails we retry it with exponential back-off and with a maximum elapsed time of 15 minutes. After that the next step runner exits, and then the agent will register again. A side effect of that is that if the host is explicitly deleted then it will be automatically re-added aftor those 15 minutes, because the agent will receive a 404 error. That isn't desired. To address it this patch changes the back-off configuration so that it doesn't have a maximum elapsed time. That means that we will now retry every 5 minutes, for ever.

Note that the back-off library that we use has a default randomization factor of 0.5, so the actual intervals will not be exactly five minutes, they will be between 2m30s and 7m30s.

Related: https://issues.redhat.com/browse/MGMT-13111