### PR TITLE
OCPBUGS-16373: Ignore arping errors on RHEL 9

### DIFF
--- a/src/connectivity_check/ipv4_arping_checker.go
+++ b/src/connectivity_check/ipv4_arping_checker.go
@@ -1,6 +1,7 @@
 package connectivity_check
 
 import (
+	"os/exec"
 	"regexp"
 	"sort"
 	"strings"
@@ -25,8 +26,11 @@ func (p *arpingChecker) Check(attributes Attributes) ResultReporter {
 
 	result, err := p.executer.Execute("arping", "-c", "10", "-w", "5", "-I", attributes.OutgoingNIC.Name, attributes.RemoteIPAddress)
 	if err != nil {
-		log.WithError(err).Error("Error while processing 'arping' command")
-		return nil
+		// Ignore exit code of 1; only 2 or -1 are actual errors
+		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
+			log.WithError(err).Error("Error while processing 'arping' command")
+			return nil
+		}
 	}
 	lines := strings.Split(result, "\n")
 	if len(lines) == 0 {


### PR DESCRIPTION
Newer versions of arping usually return 1 for usually spurious reasons. Previous versions never returned 1. Actual errors are indicated by returning 2 or -1.

Therefore treat return codes 0 and 1 as equivalent to give the same behaviour on RHEL 9 as on RHEL 8.