### PR TITLE
Revert "MGMT-15235: Compile with CGO_ENABLED=1 for FIPS"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BIN = $(ROOT_DIR)/build
 
 # Multiarch support.  Transform argument passed from docker buidx tool to go build arguments to support cross compiling
 GO_BUILD_ARCHITECTURE_VARS := $(if ${TARGETPLATFORM},$(shell echo ${TARGETPLATFORM} | awk -F / '{printf("GOOS=%s GOARCH=%s", $$1, $$2)}'),)
-GO_BUILD_VARS := CGO_ENABLED=1 $(GO_BUILD_ARCHITECTURE_VARS)
+GO_BUILD_VARS := CGO_ENABLED=0 $(GO_BUILD_ARCHITECTURE_VARS)
 
 REPORTS ?= $(ROOT_DIR)/reports
 CI ?= false


### PR DESCRIPTION
Reverts openshift/assisted-installer-agent#569

Multi-arch build errors occur because of the initial change.
Reverting until further investigation can be completed.

See slack thread https://redhat-internal.slack.com/archives/C014N2VLTQE/p1690385559654819