### PR TITLE
MGMT-13111: Freeze on `404 Not Found`

### DIFF
--- a/src/commands/step_processor.go
+++ b/src/commands/step_processor.go
@@ -236,7 +236,11 @@ func (s *stepSession) processSingleSession() (delay time.Duration, exit bool, er
 		invalidateCache(s.stepCache)
 		switch err.(type) {
 		case *installer.V2GetNextStepsNotFound:
-			err = errors.Wrapf(err, "infra-env %s was not found in inventory or user is not authorized", s.agentConfig.InfraEnvID)
+			s.Logger().WithError(err).Errorf(
+				"infra-env %s was not found in inventory, will freeze",
+				s.agentConfig.InfraEnvID,
+			)
+			select {}
 		case *installer.V2GetNextStepsUnauthorized:
 			err = errors.Wrapf(err, "user is not authenticated to perform the operation")
 		case *installer.V2GetNextStepsForbidden:


### PR DESCRIPTION
Currently when the user deletes a host the next step runner receives a `404 Not Found` response code from the server, logs it and tries again with exponential backoff. After approximately 15 minutes it stops retrying and exits, and then the main process of the agent will register the host again. The net result is that the host is automatically re-added after those 15 minutes, and we don't want that. To avoid that this patch changes the next step runner so that it freezes the agent. To register the host again the user will have to start the agent or else reboot the host.

Related: https://issues.redhat.com/browse/MGMT-13111