### PR TITLE
MGMT-14933: Detect if the host in running on OCI

### DIFF
--- a/src/inventory/system_vendor_test.go
+++ b/src/inventory/system_vendor_test.go
@@ -32,6 +32,9 @@ var _ = Describe("System vendor test", func() {
 			SerialNumber: "A Serial Number",
 			Vendor:       "A Vendor",
 		}, nil).Once()
+		dependencies.On("Chassis", ghw.WithChroot("/host")).Return(&ghw.ChassisInfo{
+			AssetTag: "An Asset Tag",
+		}, nil).Once()
 		dependencies.On("Execute", "systemd-detect-virt", "--vm").Return("none", "", 0).Once()
 
 		ret := GetVendor(dependencies)
@@ -47,6 +50,9 @@ var _ = Describe("System vendor test", func() {
 			SerialNumber: "A Serial Number",
 			Vendor:       "A Vendor",
 		}, nil).Once()
+		dependencies.On("Chassis", ghw.WithChroot("/host")).Return(&ghw.ChassisInfo{
+			AssetTag: "An Asset Tag",
+		}, nil).Once()
 		dependencies.On("Execute", "systemd-detect-virt", "--vm").Return("none", "", 0).Once()
 		systemVendor := GetVendor(dependencies)
 		Expect(systemVendor.Virtual).ShouldNot(BeTrue())
@@ -56,6 +62,9 @@ var _ = Describe("System vendor test", func() {
 			Name:         "A Name",
 			SerialNumber: "A Serial Number",
 			Vendor:       "A Vendor",
+		}, nil).Once()
+		dependencies.On("Chassis", ghw.WithChroot("/host")).Return(&ghw.ChassisInfo{
+			AssetTag: "An Asset Tag",
 		}, nil).Once()
 		dependencies.On("Execute", "systemd-detect-virt", "--vm").Return("anyvirt", "", 0).Once()
 		systemVendor := GetVendor(dependencies)
@@ -67,6 +76,9 @@ var _ = Describe("System vendor test", func() {
 			SerialNumber: "A Serial Number",
 			Vendor:       "A Vendor",
 		}, nil).Once()
+		dependencies.On("Chassis", ghw.WithChroot("/host")).Return(&ghw.ChassisInfo{
+			AssetTag: "An Asset Tag",
+		}, nil).Once()
 		dependencies.On("Execute", "systemd-detect-virt", "--vm").Return("", "an error", 1).Once()
 		systemVendor := GetVendor(dependencies)
 		Expect(systemVendor.Virtual).ShouldNot(BeTrue())
@@ -75,6 +87,9 @@ var _ = Describe("System vendor test", func() {
 		dependencies.On("Product", ghw.WithChroot("/host")).Return(&ghw.ProductInfo{
 			Family: "oVirt",
 		}, nil).Once()
+		dependencies.On("Chassis", ghw.WithChroot("/host")).Return(&ghw.ChassisInfo{
+			AssetTag: "An Asset Tag",
+		}, nil).Once()
 		dependencies.On("Execute", "systemd-detect-virt", "--vm").Return("ovirt", "", 0).Once()
 
 		ret := GetVendor(dependencies)
@@ -82,5 +97,28 @@ var _ = Describe("System vendor test", func() {
 			ProductName: "oVirt",
 			Virtual:     true,
 		}))
+	})
+	It("Chassis error", func() {
+		dependencies.On("Product", ghw.WithChroot("/host")).Return(&ghw.ProductInfo{
+			Name:         "A Name",
+			SerialNumber: "A Serial Number",
+			Vendor:       "A Vendor",
+		}, nil).Once()
+		dependencies.On("Chassis", ghw.WithChroot("/host")).Return(nil, fmt.Errorf("Just an error")).Once()
+		ret := GetVendor(dependencies)
+		Expect(ret).To(Equal(&models.SystemVendor{}))
+	})
+	It("Oracle Cloud detection", func() {
+		dependencies.On("Product", ghw.WithChroot("/host")).Return(&ghw.ProductInfo{
+			Name:         "A Name",
+			SerialNumber: "A Serial Number",
+			Vendor:       "A Vendor",
+		}, nil).Once()
+		dependencies.On("Chassis", ghw.WithChroot("/host")).Return(&ghw.ChassisInfo{
+			AssetTag: "OracleCloud.com",
+		}, nil).Once()
+		dependencies.On("Execute", "systemd-detect-virt", "--vm").Return("none", "", 0).Once()
+		systemVendor := GetVendor(dependencies)
+		Expect(systemVendor.Manufacturer).Should(Equal("OracleCloud.com"))
 	})
 })

--- a/src/util/dependencies.go
+++ b/src/util/dependencies.go
@@ -26,6 +26,7 @@ type IDependencies interface {
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
 	GPU(opts ...*ghw.WithOption) (*ghw.GPUInfo, error)
 	Memory(opts ...*ghw.WithOption) (*ghw.MemoryInfo, error)
+	Chassis(opts ...*ghw.WithOption) (*ghw.ChassisInfo, error)
 	GetGhwChrootRoot() string
 }
 
@@ -106,6 +107,10 @@ func (d *Dependencies) GPU(opts ...*ghw.WithOption) (*ghw.GPUInfo, error) {
 
 func (d *Dependencies) Memory(opts ...*ghw.WithOption) (*ghw.MemoryInfo, error) {
 	return ghw.Memory(opts...)
+}
+
+func (d *Dependencies) Chassis(opts ...*ghw.WithOption) (*ghw.ChassisInfo, error) {
+	return ghw.Chassis(opts...)
 }
 
 func NewDependencies(dryRunConfig *config.DryRunConfig, ghwChrootRoot string) IDependencies {

--- a/src/util/mock_IDependencies.go
+++ b/src/util/mock_IDependencies.go
@@ -3,9 +3,10 @@
 package util
 
 import (
-	fs "io/fs"
-
 	block "github.com/jaypipes/ghw/pkg/block"
+	chassis "github.com/jaypipes/ghw/pkg/chassis"
+
+	fs "io/fs"
 
 	gpu "github.com/jaypipes/ghw/pkg/gpu"
 
@@ -62,6 +63,35 @@ func (_m *MockIDependencies) Block(opts ...*option.Option) (*block.Info, error) 
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*block.Info)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(...*option.Option) error); ok {
+		r1 = rf(opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Chassis provides a mock function with given fields: opts
+func (_m *MockIDependencies) Chassis(opts ...*option.Option) (*chassis.Info, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *chassis.Info
+	if rf, ok := ret.Get(0).(func(...*option.Option) *chassis.Info); ok {
+		r0 = rf(opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*chassis.Info)
 		}
 	}
 


### PR DESCRIPTION
Look at chassis.asset_tag to check if the host (VM or BM) runs on Oracle
Cloud Infrastructure (OCI).
If we find out that the host runs on OCI, we override the manufacturer.
