### PR TITLE
MGMT-15235: Compile with CGO_ENABLED=1 for amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,12 @@ BIN = $(ROOT_DIR)/build
 
 # Multiarch support.  Transform argument passed from docker buidx tool to go build arguments to support cross compiling
 GO_BUILD_ARCHITECTURE_VARS := $(if ${TARGETPLATFORM},$(shell echo ${TARGETPLATFORM} | awk -F / '{printf("GOOS=%s GOARCH=%s", $$1, $$2)}'),)
-GO_BUILD_VARS := CGO_ENABLED=0 $(GO_BUILD_ARCHITECTURE_VARS)
+GO_BUILD_VARS = 
+ifeq ($(TARGETPLATFORM),linux/amd64)
+	GO_BUILD_VARS = CGO_ENABLED=1 $(GO_BUILD_ARCHITECTURE_VARS)
+else
+	GO_BUILD_VARS = CGO_ENABLED=0 $(GO_BUILD_ARCHITECTURE_VARS)
+endif
 
 REPORTS ?= $(ROOT_DIR)/reports
 CI ?= false


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15235
To be FIPS-compliant, CGO_ENABLED=1 flag must be
specified for go code.
This flag along with the base image used doesn't
work for architectures other than amd64.
See previous revert PR for more information
https://github.com/openshift/assisted-installer-agent/pull/582

Slack thread discussion
https://redhat-internal.slack.com/archives/C014N2VLTQE/p1690385559654819
/cc @gamli75 @filanov