### PR TITLE
MGMT-15235: Allow setting CGO_ENABLED flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,11 @@ BIN = $(ROOT_DIR)/build
 
 # Multiarch support.  Transform argument passed from docker buidx tool to go build arguments to support cross compiling
 GO_BUILD_ARCHITECTURE_VARS := $(if ${TARGETPLATFORM},$(shell echo ${TARGETPLATFORM} | awk -F / '{printf("GOOS=%s GOARCH=%s", $$1, $$2)}'),)
-GO_BUILD_VARS = 
+CGO_FLAG := $(or $(CGO_FLAG),0)
 ifeq ($(TARGETPLATFORM),linux/amd64)
-	GO_BUILD_VARS = CGO_ENABLED=1 $(GO_BUILD_ARCHITECTURE_VARS)
-else
-	GO_BUILD_VARS = CGO_ENABLED=0 $(GO_BUILD_ARCHITECTURE_VARS)
+	CGO_FLAG=1
 endif
+GO_BUILD_VARS := CGO_ENABLED=$(CGO_FLAG) $(GO_BUILD_ARCHITECTURE_VARS)
 
 REPORTS ?= $(ROOT_DIR)/reports
 CI ?= false


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15235
To be FIPS-compliant, CGO_ENABLED=1 flag must be
specified for go code.

This PR introduces the CGO_FLAG for builds that
need to change what CGO_ENABLED is set to
such as the ACM builds.

AMD64 builds will always set the CGO_FLAG to 1
for FIPs, which translates to CGO_ENABLED=1.

----------------------

See slack thread for more information:
https://redhat-internal.slack.com/archives/C05BCTGEGAK/p1691607687429729?thread_ts=1691590437.166799&cid=C05BCTGEGAK

/cc @filanov @gamli75 @smithbw88 