### PR TITLE
OCPBUGS-16482: bump golangci-lint to v1.53.1

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -4,7 +4,7 @@ ENV GOFLAGS=""
 
 RUN yum install -y docker docker-compose && \
     yum clean all
-COPY --from=quay.io/app-sre/golangci-lint:v1.46.0 /usr/bin/golangci-lint /usr/bin/golangci-lint
+COPY --from=quay.io/app-sre/golangci-lint:v1.53.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
 RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
     go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
     go install github.com/golang/mock/mockgen@v1.6.0 && \

--- a/src/free_addresses/free_addresses.go
+++ b/src/free_addresses/free_addresses.go
@@ -31,7 +31,7 @@ func (e *ProcessExecuter) Execute(command string, args ...string) (stdout string
 	return util.Execute(command, args...)
 }
 
-//  http://play.golang.org/p/m8TNTtygK0
+// http://play.golang.org/p/m8TNTtygK0
 func inc(ip net.IP) {
 	for j := len(ip) - 1; j >= 0; j-- {
 		ip[j]++

--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -221,7 +221,7 @@ func (d *disks) getApplianceDisks(blockDisks []*block.Disk) []*models.Disk {
 
 	// Return a disk with some mock data to skip all validations
 	return []*models.Disk{
-		&models.Disk{
+		{
 			ByID:                    d.getDisksWWNs()[path],
 			ByPath:                  d.getByPath(dmDevice.BusPath),
 			Hctl:                    "",

--- a/src/tang_connectivity_check/tang_connectivity_check_test.go
+++ b/src/tang_connectivity_check/tang_connectivity_check_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type ClientMock struct {}
+type ClientMock struct{}
 
 func (c *ClientMock) Do(req *http.Request) (*http.Response, error) {
 	if strings.Contains(req.URL.String(), "127.0.0.1") {

--- a/src/util/network.go
+++ b/src/util/network.go
@@ -14,22 +14,23 @@ func IsIPv4Addr(ip string) bool {
 	return strings.Contains(ip, ".") && net.ParseIP(ip) != nil
 }
 
-//RouteFinder defines functions needed to find routes by link
+// RouteFinder defines functions needed to find routes by link
+//
 //go:generate mockery --name RouteFinder --inpackage
 type RouteFinder interface {
 	LinkByName(name string) (netlink.Link, error)
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
 }
 
-//NetlinkRouteFinder implements RouteFinder using netling library
+// NetlinkRouteFinder implements RouteFinder using netling library
 type NetlinkRouteFinder struct{}
 
-//LinkByName returns a link by a network interface name, it such interface exists
+// LinkByName returns a link by a network interface name, it such interface exists
 func (f *NetlinkRouteFinder) LinkByName(name string) (netlink.Link, error) {
 	return netlink.LinkByName(name)
 }
 
-//RouteList returns a list of routes filtered by a link and IP family (IPv4/IPv6)
+// RouteList returns a list of routes filtered by a link and IP family (IPv4/IPv6)
 func (f *NetlinkRouteFinder) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
 	return netlink.RouteList(link, family)
 }


### PR DESCRIPTION
Cannot update golangci-lint in the same PR as one exhibiting issues because the CI still uses the previous version.

Updating k8s.io/apimachinery module to a newer version causes the old linter to throw nil pointer error.

Example [PR#590](https://github.com/openshift/assisted-installer-agent/pull/590)

Includes formatting changes by the linter.