### PR TITLE
MGMT-15809: change base image to stream9

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -12,7 +12,7 @@ COPY . .
 
 RUN TARGETPLATFORM=$TARGETPLATFORM make build
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 ARG TARGETPLATFORM
 RUN if [[ "$TARGETPLATFORM" == "linux/amd64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y biosdevname dmidecode ; fi
 RUN if [[ "$TARGETPLATFORM" == "linux/arm64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y dmidecode ; fi
@@ -31,6 +31,8 @@ RUN dnf install --setopt=install_weak_deps=False --setopt=tsdocs=False -y \
 		tar openssh-clients \
 		# ntp_synchronizer
 		chrony \
+		# for the 'nsenter' executable
+		util-linux-core \
 		&& dnf update --setopt=install_weak_deps=False --setopt=tsdocs=False -y systemd && dnf clean all && rm -rf /var/cache
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/agent /usr/bin/agent

--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -12,3 +12,6 @@ RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
     go install gotest.tools/gotestsum@v1.6.3 && \
     go install github.com/axw/gocov/gocov@latest && \
     go install github.com/AlekSi/gocov-xml@latest
+
+# required due to issue https://github.com/docker/compose/issues/4060
+ENV LANG=en_US.UTF-8

--- a/subsystem/Dockerfile.agent_test
+++ b/subsystem/Dockerfile.agent_test
@@ -1,15 +1,15 @@
 ARG ASSISTED_INSTALLER_AGENT=quay.io/edge-infrastructure/assisted-installer-agent:latest
 FROM $ASSISTED_INSTALLER_AGENT
 
-RUN yum install -y yum-utils \
-    && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
-    && dnf install -y --nobest --allowerasing \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    tcpdump \
-    procps \
-    python39 \
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y --nobest --allowerasing \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        tcpdump \
+        procps \
+        python39 \
     && dnf clean all
 
 RUN echo -e "#!/bin/sh \nshift 7 && \$@" > /usr/bin/nsenter && chmod a+x /usr/bin/nsenter

--- a/subsystem/lease_test.go
+++ b/subsystem/lease_test.go
@@ -238,7 +238,7 @@ func startTcpDump(output chan string, ifaceName string, timeoutSecs, count int) 
 	if count > 0 {
 		countStr = fmt.Sprintf("-c %d", count)
 	}
-	dump := fmt.Sprintf("timeout %d tcpdump -l -i %s %s -v 'udp dst port 67' | awk '/DHCP-Message Option 53/{print $6}'", timeoutSecs, ifaceName, countStr)
+	dump := fmt.Sprintf("timeout %d tcpdump -l -i %s %s -v 'udp dst port 67' | awk '/DHCP-Message \\(53\\)/{print $5}'", timeoutSecs, ifaceName, countStr)
 
 	s, e, errorCode := agentUtils.Execute("docker", []string{"exec", "agent", "bash", "-c", dump}...)
 	fmt.Println(s, e, errorCode)


### PR DESCRIPTION
Now that D/S building system fully supports RHEL-9 base images (and allows easy installation of nmstate and other libs that were previously unsupported) we can move U/S to stream9 and D/S to ubi9-minimal.

It doesn't seem possible to easily use ubi9-minimal U/S for the assisted-service, because installation of nmstate packages either requires entitlements running on a RHEL node, or alternatively an access to RedHat's internal network (which can be a major problem for U/S development). For a better consistency we're sticking with the same for the agent, installer, etc.