### PR TITLE
NO-ISSUE: fix lint target and code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ci-lint: vendor-diff
 	${ROOT_DIR}/hack/sync-dockerfiles.sh
 
 lint: ci-lint
-	golangci-lint run -v --fix
+	golangci-lint run -v
 
 .PHONY: build clean build-image push subsystem
 build: build-agent build-inventory build-free_addresses build-logs_sender \

--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -221,7 +221,7 @@ func (d *disks) getApplianceDisks(blockDisks []*block.Disk) []*models.Disk {
 
 	// Return a disk with some mock data to skip all validations
 	return []*models.Disk{
-		&models.Disk{
+		{
 			ByID:                    d.getDisksWWNs()[path],
 			ByPath:                  d.getByPath(dmDevice.BusPath),
 			Hctl:                    "",

--- a/src/tang_connectivity_check/tang_connectivity_check_test.go
+++ b/src/tang_connectivity_check/tang_connectivity_check_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type ClientMock struct {}
+type ClientMock struct{}
 
 func (c *ClientMock) Do(req *http.Request) (*http.Response, error) {
 	if strings.Contains(req.URL.String(), "127.0.0.1") {


### PR DESCRIPTION
For some reason we applied ``--fix`` to the lint code, which fixes the issues and return a 0 code (so the job always passes).

This removes it and fixes the lint issues in code.