### PR TITLE
Shrink agent image

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -10,36 +10,48 @@ RUN go mod download
 
 COPY . .
 
-RUN TARGETPLATFORM=$TARGETPLATFORM make build
+RUN TARGETPLATFORM=$TARGETPLATFORM make build-release
 
 FROM quay.io/centos/centos:stream9
 ARG TARGETPLATFORM
-RUN if [[ "$TARGETPLATFORM" == "linux/amd64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y biosdevname dmidecode ; fi
-RUN if [[ "$TARGETPLATFORM" == "linux/arm64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y dmidecode ; fi
 
-RUN dnf install --setopt=install_weak_deps=False --setopt=tsdocs=False -y \
-		findutils iputils \
-		podman \
-		# inventory
-		ipmitool file fio \
-		sg3_utils \
-		# free_addresses
-		nmap \
-		# dhcp_lease_allocate
-		dhclient \
-		# logs_sender
-		tar openssh-clients \
-		# ntp_synchronizer
-		chrony \
-		# for the 'nsenter' executable
-		util-linux-core \
-		&& dnf update --setopt=install_weak_deps=False --setopt=tsdocs=False -y systemd && dnf clean all && rm -rf /var/cache
+RUN if [[ "$TARGETPLATFORM" == "linux/amd64" || -z "$TARGETPLATFORM" ]] ; then dnf install -y biosdevname dmidecode ; fi ; \
+    if [[ "$TARGETPLATFORM" == "linux/arm64" || -z "$TARGETPLATFORM" ]] ; then dnf install -y dmidecode ; fi ; \
+    dnf install --setopt=install_weak_deps=False --setopt=tsdocs=False -y \
+            findutils iputils \
+            podman \
+            # inventory
+            ipmitool file \
+            sg3_utils \
+            # disk_speed_check
+            fio \
+            # free_addresses
+            nmap \
+            # dhcp_lease_allocate
+            dhclient \
+            # logs_sender
+            tar openssh-clients \
+            # ntp_synchronizer
+            chrony \
+            # for the 'nsenter' executable
+            util-linux-core \
+            && dnf update --setopt=install_weak_deps=False --setopt=tsdocs=False -y systemd && dnf clean all && rm -rf /var/cache \
+            # Clean unnecessary nmap files to reduce image size
+            && find /usr/share/nmap/ -mindepth 1 -maxdepth 1 | grep -v nmap-payloads | xargs rm -rf \
+            # Remove cracklib installed as part of systemd to reduce image size
+            && rm -rf /usr/share/cracklib \
+            # Remove manpages && docs to reduce image size
+            && rm -rf /usr/share/man /usr/share/doc \
+            # Remove RPM/DNF files to reduce image size
+            && rm -rf /var/lib/rpm/rpmdb.sqlite /var/lib/dnf
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/agent /usr/bin/agent
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/free_addresses /usr/bin/free_addresses
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/inventory /usr/bin/inventory
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/logs_sender /usr/bin/logs_sender
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/next_step_runner /usr/bin/next_step_runner
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/disk_speed_check /usr/bin/disk_speed_check
+
+# The step binaries are all symlinks to /usr/bin/agent
+RUN ln -s /usr/bin/agent /usr/bin/free_addresses && \
+    ln -s /usr/bin/agent /usr/bin/inventory && \
+    ln -s /usr/bin/agent /usr/bin/logs_sender && \
+    ln -s /usr/bin/agent /usr/bin/next_step_runner && \
+    ln -s /usr/bin/agent /usr/bin/disk_speed_check
 
 COPY scripts/installer/* /usr/local/bin/

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -10,12 +10,11 @@ FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 LABEL io.openshift.release.operator=true
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/agent /usr/bin/agent
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/inventory /usr/bin/inventory
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/free_addresses /usr/bin/free_addresses
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/logs_sender /usr/bin/logs_sender
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/next_step_runner /usr/bin/next_step_runner
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/disk_speed_check /usr/bin/disk_speed_check
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/scripts/installer/* /usr/local/bin/
+RUN ln -s /usr/bin/agent /usr/bin/free_addresses && \
+    ln -s /usr/bin/agent /usr/bin/inventory && \
+    ln -s /usr/bin/agent /usr/bin/logs_sender && \
+    ln -s /usr/bin/agent /usr/bin/next_step_runner && \
+    ln -s /usr/bin/agent /usr/bin/disk_speed_check
 
 RUN if [ "$(arch)" -eq "x86_64" ]; then dnf install -y biosdevname dmidecode; fi
 RUN if [ "$(arch)" -eq "aarch64" ]; then dnf install -y dmidecode; fi

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,15 @@ lint: ci-lint
 	golangci-lint run -v
 
 .PHONY: build clean build-image push subsystem
-build: build-agent build-inventory build-free_addresses build-logs_sender \
-	   build-next_step_runner build-disk_speed_check
+build: build-agent
 
-build-%: $(BIN) src/$* #lint
-	$(GO_BUILD_VARS) go build -o $(BIN)/$* src/$*/main/main.go
+build-agent: $(BIN) src/agent #lint
+	$(GO_BUILD_VARS) go build -o $(BIN)/agent src/agent/main/main.go 
+
+build-release: build-agent-release
+
+build-agent-release: $(BIN) src/agent #lint
+	$(GO_BUILD_VARS) go build -o $(BIN)/agent -ldflags "-s -w" src/agent/main/main.go
 
 build-image:
 	docker build ${CONTAINER_BUILD_PARAMS} -f Dockerfile.assisted_installer_agent . -t $(ASSISTED_INSTALLER_AGENT)

--- a/src/agent/main/main.go
+++ b/src/agent/main/main.go
@@ -1,13 +1,56 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
 	"github.com/openshift/assisted-installer-agent/src/agent"
 	"github.com/openshift/assisted-installer-agent/src/config"
+	"github.com/openshift/assisted-installer-agent/src/disk_speed_check"
+	"github.com/openshift/assisted-installer-agent/src/free_addresses"
+	"github.com/openshift/assisted-installer-agent/src/inventory"
+	"github.com/openshift/assisted-installer-agent/src/logs_sender"
+	"github.com/openshift/assisted-installer-agent/src/next_step_runner"
 	"github.com/openshift/assisted-installer-agent/src/util"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
+	if len(os.Args) == 0 {
+		logrus.Fatal("No arguments were passed to the agent")
+	}
+
+	// All binaries are actually just symlinks to the same agent binary, so we
+	// need to check the binary name to know which binary we're supposed to
+	// behave as
+	binaryName := filepath.Base(os.Args[0])
+	binaries := map[string]func(){
+		"agent":            Main,
+		"free_addresses":   free_addresses.Main,
+		"inventory":        inventory.Main,
+		"logs_sender":      logs_sender.Main,
+		"next_step_runner": next_step_runner.Main,
+		"disk_speed_check": disk_speed_check.Main,
+	}
+	if mainFunc, ok := binaries[binaryName]; ok {
+		mainFunc()
+	} else {
+		logrus.Fatalf("unknown binary name %s, expected one of %s", binaryName, strings.Join(getMapKeysSorted(binaries), ", "))
+	}
+}
+
+func getMapKeysSorted(binaries map[string]func()) []string {
+	keys := make([]string, 0, len(binaries))
+	for k := range binaries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func Main() {
 	agentConfig := config.ProcessArgs()
 	config.ProcessDryRunArgs(&agentConfig.DryRunConfig)
 	util.SetLogging("agent_registration", agentConfig.TextLogging, agentConfig.JournalLogging, agentConfig.StdoutLogging, agentConfig.ForcedHostID)

--- a/src/disk_speed_check/main.go
+++ b/src/disk_speed_check/main.go
@@ -1,4 +1,4 @@
-package main
+package disk_speed_check
 
 import (
 	"flag"
@@ -6,18 +6,17 @@ import (
 	"os"
 
 	"github.com/openshift/assisted-installer-agent/src/config"
-	"github.com/openshift/assisted-installer-agent/src/disk_speed_check"
 	"github.com/openshift/assisted-installer-agent/src/util"
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func Main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
 	util.SetLogging("disk-speed-check", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
 
 	req := flag.Arg(flag.NArg() - 1)
-	perfCheck := disk_speed_check.NewDiskSpeedCheck(subprocessConfig, disk_speed_check.NewDependencies())
+	perfCheck := NewDiskSpeedCheck(subprocessConfig, NewDependencies())
 	stdout, stderr, exitCode := perfCheck.FioPerfCheck(req, log.StandardLogger())
 	fmt.Fprint(os.Stdout, stdout)
 	fmt.Fprint(os.Stderr, stderr)

--- a/src/free_addresses/main.go
+++ b/src/free_addresses/main.go
@@ -1,4 +1,4 @@
-package main
+package free_addresses
 
 import (
 	"flag"
@@ -8,11 +8,10 @@ import (
 	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-installer-agent/src/util"
 
-	"github.com/openshift/assisted-installer-agent/src/free_addresses"
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func Main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
 	util.SetLogging("free_addresses", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
@@ -20,7 +19,7 @@ func main() {
 		log.Warnf("Expecting exactly single argument to free_addresses. Received %d", len(os.Args)-1)
 		os.Exit(-1)
 	}
-	stdout, stderr, exitCode := free_addresses.GetFreeAddresses(flag.Arg(0), &free_addresses.ProcessExecuter{}, log.StandardLogger())
+	stdout, stderr, exitCode := GetFreeAddresses(flag.Arg(0), &ProcessExecuter{}, log.StandardLogger())
 	fmt.Fprint(os.Stdout, stdout)
 	fmt.Fprint(os.Stderr, stderr)
 	os.Exit(exitCode)

--- a/src/inventory/main.go
+++ b/src/inventory/main.go
@@ -1,16 +1,15 @@
-package main
+package inventory
 
 import (
 	"fmt"
 
 	"github.com/openshift/assisted-installer-agent/src/config"
-	"github.com/openshift/assisted-installer-agent/src/inventory"
 	"github.com/openshift/assisted-installer-agent/src/util"
 )
 
-func main() {
+func Main() {
 	subprocessConfig := config.ProcessSubprocessArgs(config.DefaultLoggingConfig)
 	config.ProcessDryRunArgs(&subprocessConfig.DryRunConfig)
 	util.SetLogging("inventory", subprocessConfig.TextLogging, subprocessConfig.JournalLogging, subprocessConfig.StdoutLogging, subprocessConfig.ForcedHostID)
-	fmt.Print(string(inventory.CreateInventoryInfo(subprocessConfig)))
+	fmt.Print(string(CreateInventoryInfo(subprocessConfig)))
 }

--- a/src/logs_sender/main.go
+++ b/src/logs_sender/main.go
@@ -1,20 +1,18 @@
-package main
+package logs_sender
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/openshift/assisted-installer-agent/src/logs_sender"
-
 	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-installer-agent/src/util"
 )
 
-func main() {
+func Main() {
 	loggingConfig := config.ProcessLogsSenderConfigArgs(true, true)
 	config.ProcessDryRunArgs(&loggingConfig.DryRunConfig)
 	util.SetLogging("logs-sender", loggingConfig.TextLogging, loggingConfig.JournalLogging, loggingConfig.StdoutLogging, loggingConfig.ForcedHostID)
-	err, report := logs_sender.SendLogs(loggingConfig, logs_sender.NewLogsSenderExecuter(loggingConfig, loggingConfig.TargetURL,
+	err, report := SendLogs(loggingConfig, NewLogsSenderExecuter(loggingConfig, loggingConfig.TargetURL,
 		loggingConfig.PullSecretToken,
 		loggingConfig.AgentVersion))
 	if err != nil {

--- a/src/next_step_runner/main.go
+++ b/src/next_step_runner/main.go
@@ -1,4 +1,4 @@
-package main
+package next_step_runner
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func Main() {
 	agentConfig := config.ProcessArgs()
 	config.ProcessDryRunArgs(&agentConfig.DryRunConfig)
 	util.SetLogging("agent_next_step_runner", agentConfig.TextLogging, agentConfig.JournalLogging, agentConfig.StdoutLogging, agentConfig.ForcedHostID)


### PR DESCRIPTION
[MGMT-16011](https://issues.redhat.com//browse/MGMT-16011)

See commit message for information on what changed

From **606MB** to **315MB** (48% reduction)

# Analysis

## Base image size: **154MB**

## Original additional layers total size: **452MB**
* **245MB** dnf installations layers
* **207MB** agent binaries (**53MB** + **13MB** + **14MB** + **56MB** + **59MB** + **12MB**)

## New additional layers total size: **160MB** 
* **118MB** dnf installations layer
* **42MB** agent binary

## Summary

65% reduction in added size.

## This seems to be rock bottom:

* Half the total size is now just the base image
* It's difficult to make the agent binary any smaller, go binaries are just big
* 50% of the size DNF installations layer is just podman which is not something we can replace
* The rest of the dnf installations layer is full of small tools we rely on

# Downstream

We need to perform similar work also on the downstream Dockerfile, which creates images that weigh much more