### PR TITLE
MGMT-16335: set HasUUID on appliance mock disk

### DIFF
--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -219,6 +219,11 @@ func (d *disks) getApplianceDisks(blockDisks []*block.Disk) []*models.Disk {
 	// Set size to 100GiB to avoid validation
 	sizeBytes := conversions.GibToBytes(100)
 
+	// Determine whether any device has UUID (implies that the appliance device has one)
+	hasUUID := funk.Any(funk.Filter(blockDisks, func(blockDisk *block.Disk) bool {
+		return d.hasUUID(d.getPath(blockDisk.BusPath, blockDisk.Name))
+	}))
+
 	// Return a disk with some mock data to skip all validations
 	return []*models.Disk{
 		{
@@ -238,7 +243,7 @@ func (d *disks) getApplianceDisks(blockDisks []*block.Disk) []*models.Disk {
 			Smart:                   "",
 			IsInstallationMedia:     false,
 			InstallationEligibility: models.DiskInstallationEligibility{Eligible: true},
-			HasUUID:                 false,
+			HasUUID:                 hasUUID,
 			Holders:                 "",
 		},
 	}

--- a/src/inventory/disks_test.go
+++ b/src/inventory/disks_test.go
@@ -946,8 +946,9 @@ var _ = Describe("Disks test", func() {
 		disk := createDeviceMapperDisk()
 		disk.Name = "dm-0"
 		mockFetchDisks(dependencies, nil, disk)
-		mockGetPathFromDev(dependencies, disk.Name, "")
+		mockGetPathFromDev(dependencies, disk.Name, "").Twice()
 		mockGetWWNCallForSuccess(dependencies, make(map[string]string))
+		mockHasUUID(dependencies, "/dev/dm-0", "")
 		dependencies.On("ReadFile", fmt.Sprintf("/sys/block/%s/dm/name", disk.Name)).Return([]byte(applianceAgentPrefix), nil)
 
 		ret := GetDisks(&config.SubprocessConfig{}, dependencies)
@@ -966,6 +967,7 @@ var _ = Describe("Disks test", func() {
 				Bootable:  false,
 				Smart:     "",
 				Holders:   "",
+				HasUUID:   true,
 				InstallationEligibility: models.DiskInstallationEligibility{
 					Eligible: true,
 				},


### PR DESCRIPTION
In order to support deploying the appliance on a vSphere env, set the HasUUID property on the appliance fake disk. I.e. use the 'hasUUID' func that handles vSphere disks.