### PR TITLE
[release-ocm-2.9] MGMT-16370: fix golangci-lint failing to be pulled

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -4,7 +4,7 @@ ENV GOFLAGS=""
 
 RUN yum install -y docker docker-compose && \
     yum clean all
-COPY --from=quay.io/app-sre/golangci-lint:v1.46.0 /usr/bin/golangci-lint /usr/bin/golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.46.0
 RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
     go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
     go install github.com/golang/mock/mockgen@v1.6.0 && \


### PR DESCRIPTION
app-sre made their repo mirroring golangci-lint private for legal reasons, and
now our jobs are failing to install it. Installing it now from the cli.

We could also have pulled golangci-lint from dockerhub, but rate
limitation there is quite aggressive.
