### PR TITLE
MGMT-14226: Upgrade docker to 20.10.24 for CVE-2023-28842

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/coreos/vcontext v0.0.0-20230201181013-d72178a18687 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v20.10.14+incompatible // indirect
-	github.com/docker/docker v20.10.14+incompatible // indirect
+	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -374,8 +374,9 @@ github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v20.10.14+incompatible h1:+T9/PRYWNDo5SZl5qS1r9Mo/0Q8AwxKKPtu9S1yxM0w=
 github.com/docker/docker v20.10.14+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.24+incompatible h1:Ugvxm7a8+Gz6vqQYQQ2W7GYq5EUPaAiuPgIfVyI3dYE=
+github.com/docker/docker v20.10.24+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/vendor/github.com/docker/docker/api/types/container/hostconfig_unix.go
+++ b/vendor/github.com/docker/docker/api/types/container/hostconfig_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package container // import "github.com/docker/docker/api/types/container"

--- a/vendor/github.com/docker/docker/api/types/filters/parse.go
+++ b/vendor/github.com/docker/docker/api/types/filters/parse.go
@@ -1,4 +1,5 @@
-/*Package filters provides tools for encoding a mapping of keys to a set of
+/*
+Package filters provides tools for encoding a mapping of keys to a set of
 multiple values.
 */
 package filters // import "github.com/docker/docker/api/types/filters"
@@ -48,7 +49,7 @@ func (args Args) Keys() []string {
 // MarshalJSON returns a JSON byte representation of the Args
 func (args Args) MarshalJSON() ([]byte, error) {
 	if len(args.fields) == 0 {
-		return []byte{}, nil
+		return []byte("{}"), nil
 	}
 	return json.Marshal(args.fields)
 }
@@ -106,9 +107,6 @@ func FromJSON(p string) (Args, error) {
 
 // UnmarshalJSON populates the Args from JSON encode bytes
 func (args Args) UnmarshalJSON(raw []byte) error {
-	if len(raw) == 0 {
-		return nil
-	}
 	return json.Unmarshal(raw, &args.fields)
 }
 

--- a/vendor/github.com/docker/docker/api/types/registry/registry.go
+++ b/vendor/github.com/docker/docker/api/types/registry/registry.go
@@ -45,31 +45,32 @@ func (ipnet *NetIPNet) UnmarshalJSON(b []byte) (err error) {
 // IndexInfo contains information about a registry
 //
 // RepositoryInfo Examples:
-// {
-//   "Index" : {
-//     "Name" : "docker.io",
-//     "Mirrors" : ["https://registry-2.docker.io/v1/", "https://registry-3.docker.io/v1/"],
-//     "Secure" : true,
-//     "Official" : true,
-//   },
-//   "RemoteName" : "library/debian",
-//   "LocalName" : "debian",
-//   "CanonicalName" : "docker.io/debian"
-//   "Official" : true,
-// }
 //
-// {
-//   "Index" : {
-//     "Name" : "127.0.0.1:5000",
-//     "Mirrors" : [],
-//     "Secure" : false,
-//     "Official" : false,
-//   },
-//   "RemoteName" : "user/repo",
-//   "LocalName" : "127.0.0.1:5000/user/repo",
-//   "CanonicalName" : "127.0.0.1:5000/user/repo",
-//   "Official" : false,
-// }
+//	{
+//	  "Index" : {
+//	    "Name" : "docker.io",
+//	    "Mirrors" : ["https://registry-2.docker.io/v1/", "https://registry-3.docker.io/v1/"],
+//	    "Secure" : true,
+//	    "Official" : true,
+//	  },
+//	  "RemoteName" : "library/debian",
+//	  "LocalName" : "debian",
+//	  "CanonicalName" : "docker.io/debian"
+//	  "Official" : true,
+//	}
+//
+//	{
+//	  "Index" : {
+//	    "Name" : "127.0.0.1:5000",
+//	    "Mirrors" : [],
+//	    "Secure" : false,
+//	    "Official" : false,
+//	  },
+//	  "RemoteName" : "user/repo",
+//	  "LocalName" : "127.0.0.1:5000/user/repo",
+//	  "CanonicalName" : "127.0.0.1:5000/user/repo",
+//	  "Official" : false,
+//	}
 type IndexInfo struct {
 	// Name is the name of the registry, such as "docker.io"
 	Name string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -90,7 +90,7 @@ github.com/docker/cli/cli/compose/schema
 github.com/docker/cli/cli/compose/template
 github.com/docker/cli/cli/compose/types
 github.com/docker/cli/opts
-# github.com/docker/docker v20.10.14+incompatible
+# github.com/docker/docker v20.10.24+incompatible
 ## explicit
 github.com/docker/docker/api/types
 github.com/docker/docker/api/types/blkiodev


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-14226
Upgrades go dependency github.com/docker/docker to 20.10.24 to fix CVE. GHSA-33pg-m6jh-5237