### PR TITLE
MGMT-16459: [STG] Cluster 4.15.0-rc.0 with HTTP Proxy failed on timeout due the failed to StartContainer for etcd with CrashLoopBackOff

### DIFF
--- a/src/commands/actions/install_cmd.go
+++ b/src/commands/actions/install_cmd.go
@@ -145,7 +145,7 @@ func (a *install) getFullInstallerCommand() string {
 	}
 
 	if a.installParams.EnableSkipMcoReboot {
-		installerCmdArgs = append(installerCmdArgs, "--enable-skip-mco-reboot", "true")
+		installerCmdArgs = append(installerCmdArgs, "--enable-skip-mco-reboot")
 	}
 
 	proxyArgs := getProxyArguments(a.installParams.Proxy)

--- a/src/commands/actions/install_cmd_test.go
+++ b/src/commands/actions/install_cmd_test.go
@@ -246,7 +246,7 @@ var _ = Describe("installer test", func() {
 		installCommandRequest.EnableSkipMcoReboot = true
 		action := getInstall(installCommandRequest, filesystem, false)
 		args := action.Args()
-		Expect(strings.Join(args, " ")).To(ContainSubstring("--enable-skip-mco-reboot true"))
+		Expect(strings.Join(args, " ")).To(ContainSubstring("--enable-skip-mco-reboot"))
 	})
 
 	It("install no installer args", func() {


### PR DESCRIPTION
If golang boolean flag has value, it must appear in the form '--flag=<value>'.  In our case the value 'true' was appended after space which caused the flag parser in assisted-installer to stop parsing. This caused all the flags after this flag to be ignored which were the proxy flags.

/cc @avishayt 