### PR TITLE
NO-ISSUE: subsystem test failing due image format version

### DIFF
--- a/subsystem/agent_test.go
+++ b/subsystem/agent_test.go
@@ -301,7 +301,7 @@ var _ = Describe("Agent tests", func() {
 		hostID := nextHostID()
 		registerStubID, err := addRegisterStub(hostID, http.StatusCreated, InfraEnvID)
 		Expect(err).NotTo(HaveOccurred())
-		images := []string{"quay.io/coreos/etcd:latest"}
+		images := []string{"quay.io/coreos/etcd:v3.5.13"}
 		removeImage(defaultContainerTool, images[0])
 		url := WireMockURLFromSubsystemHost + TestWorkerIgnitionPath
 		_, err = addWorkerIgnitionStub()

--- a/subsystem/container_image_availability_test.go
+++ b/subsystem/container_image_availability_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Image availability tests", func() {
 	})
 
 	It("Valid new images", func() {
-		images = []string{"quay.io/ibm/hello-world", "quay.io/coreos/etcd:latest"}
+		images = []string{"quay.io/ibm/hello-world", "quay.io/coreos/etcd:v3.5.13"}
 
 		for _, image := range images {
 			deleteImage(image)

--- a/subsystem/container_image_availability_test.go
+++ b/subsystem/container_image_availability_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Image availability tests", func() {
 	})
 
 	It("Valid new images", func() {
-		images = []string{"quay.io/aptible/hello-world", "quay.io/coreos/etcd:latest"}
+		images = []string{"quay.io/ibm/hello-world", "quay.io/coreos/etcd:latest"}
 
 		for _, image := range images {
 			deleteImage(image)
@@ -50,7 +50,7 @@ var _ = Describe("Image availability tests", func() {
 	})
 
 	It("Already downloaded image", func() {
-		images = []string{"quay.io/aptible/hello-world"}
+		images = []string{"quay.io/ibm/hello-world"}
 
 		for _, image := range images {
 			deleteImage(image)


### PR DESCRIPTION
when pulling the image using Docker it create a validation error 

```console
> docker pull quay.io/aptible/hello-world                                                                                     
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of qua
y.io/aptible/hello-world:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/ 
```