### PR TITLE
MGMT-17541: Replace broken golangci reference

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -4,7 +4,7 @@ ENV GOFLAGS=""
 
 RUN yum install -y docker docker-compose && \
     yum clean all
-COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.37.1
 RUN go get -u golang.org/x/tools/cmd/goimports@v0.1.0 \
               github.com/onsi/ginkgo/ginkgo@v1.16.1  \
               github.com/golang/mock/mockgen@v1.4.3  \


### PR DESCRIPTION
The reference to the quay image has been replaced with RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.37.1 Which installs v1.37.1 of `golangci-lint` into the skipper build container. If we leave this unchanged, the skipper build container fails with an error about a missing image.