### PR TITLE
OCPBUGS-33404: Make removable disks eligible

### DIFF
--- a/src/inventory/disks.go
+++ b/src/inventory/disks.go
@@ -323,10 +323,6 @@ func (d *disks) isHiddenDevice(disk *ghw.Disk) bool {
 // be eligible. Also returns whether the disk appears to be an installation
 // media or not.
 func (d *disks) checkEligibility(disk *ghw.Disk) (notEligibleReasons []string, isInstallationMedia bool) {
-	if disk.IsRemovable {
-		notEligibleReasons = append(notEligibleReasons, "Disk is removable")
-	}
-
 	if disk.StorageController == ghw.STORAGE_CONTROLLER_UNKNOWN && !d.isMultipath(disk) && !d.isLVM(disk) && !d.isDASD(disk) {
 		notEligibleReasons = append(notEligibleReasons, "Disk has unknown storage controller")
 	}

--- a/src/inventory/disks_test.go
+++ b/src/inventory/disks_test.go
@@ -521,15 +521,12 @@ var _ = Describe("Disks test", func() {
 		Expect(ret).To(Equal(expectedDisks))
 	})
 
-	It("filters removable disks", func() {
+	It("removable disks should be eligible", func() {
 		blockInfo, expectedDisks := prepareDisksTest(dependencies, 1)
 
 		blockInfo.Disks[0].IsRemovable = true
 		expectedDisks[0].Removable = true
-		expectedDisks[0].InstallationEligibility.Eligible = false
-		expectedDisks[0].InstallationEligibility.NotEligibleReasons = []string{
-			"Disk is removable",
-		}
+		expectedDisks[0].InstallationEligibility.Eligible = true
 
 		mockFetchDisks(dependencies, nil, blockInfo.Disks...)
 		ret := GetDisks(&config.SubprocessConfig{}, dependencies)


### PR DESCRIPTION
Depending on machine configuration internal disks may appears as
removable.

Let's drop this check to un-block installations in such setup.
