### PR TITLE
[release-ocm-2.9] NO-ISSUE: Use archived dnf repositories for centos8 as the current ones are no longer valid

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -13,6 +13,10 @@ COPY . .
 RUN TARGETPLATFORM=$TARGETPLATFORM make build
 
 FROM quay.io/centos/centos:stream8
+
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    
 ARG TARGETPLATFORM
 RUN if [[ "$TARGETPLATFORM" == "linux/amd64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y biosdevname dmidecode ; fi
 RUN if [[ "$TARGETPLATFORM" == "linux/arm64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y dmidecode ; fi


### PR DESCRIPTION
[CentOS Linux 8 had reached the End Of Life (EOL)](https://www.centos.org/centos-linux-eol/) on December 31st, 2021. It means that CentOS 8 will no longer receive development resources from the official CentOS project. After Dec 31st, 2021, if you need to update your CentOS, you need to change the mirrors to [vault.centos.org](https://vault.centos.org/) where they will be archived permanently. Alternatively, you may want to [upgrade to CentOS Stream](https://techglimpse.com/convert-centos8-linux-centosstream/).

from - https://techglimpse.com/failed-metadata-repo-appstream-centos-8/