### PR TITLE
NO-ISSUE: Replace base golang image in the build Dockerfile

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -1,9 +1,12 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.20
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20
+
+USER 0
+
 ENV GO111MODULE=on
 ENV GOFLAGS=""
+ENV GOPATH="/go"
+ENV PATH="$PATH:$GOPATH/bin"
 
-RUN yum install -y docker docker-compose && \
-    yum clean all
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.53.2
 RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
     go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
@@ -12,6 +15,13 @@ RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
     go install gotest.tools/gotestsum@v1.6.3 && \
     go install github.com/axw/gocov/gocov@latest && \
     go install github.com/AlekSi/gocov-xml@latest
+    
+RUN dnf install -y docker
+RUN dnf clean all
+
+RUN curl -SL https://github.com/docker/compose/releases/download/v2.28.1/docker-compose-linux-x86_64 -o /tmp/docker-compose
+RUN chmod +x /tmp/docker-compose
+RUN mv /tmp/docker-compose /usr/bin
 
 # required due to issue https://github.com/docker/compose/issues/4060
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
Replace base golang image in the build Dockerfile as it is based on centos7 and it is EOL, which results in yum can't reach its repositories