### PR TITLE
[release-ocm-2.8] NO-ISSUE: Replace base golang image in the build Dockerfile

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -1,9 +1,20 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
-ENV GO111MODULE=on
-ENV GOFLAGS=""
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19
 
-RUN yum install -y docker docker-compose && \
-    yum clean all
+USER 0
+
+ENV GOFLAGS=""
+ENV GOPATH="/go"
+ENV PATH="$PATH:$GOPATH/bin"
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-compose-plugin \
+    && dnf clean all
+
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.56.0
 RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
     go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo
 GIT_REVISION := $(shell git rev-parse HEAD)
 CONTAINER_BUILD_PARAMS = --network=host --label git_revision=${GIT_REVISION} ${CONTAINER_BUILD_EXTRA_PARAMS}
 
-DOCKER_COMPOSE=docker-compose -f ./subsystem/docker-compose.yml
+DOCKER_COMPOSE=docker compose -f ./subsystem/docker-compose.yml
 
 all: build
 

--- a/subsystem/ntp_test.go
+++ b/subsystem/ntp_test.go
@@ -180,5 +180,5 @@ func getNTPResponseFromStepReply(actualReply *models.StepReply) *models.NtpSynch
 func addChronyDaemon(ctx context.Context, hostID string) {
 	s, e, errorCode := agentUtils.Execute("docker", []string{"exec", "agent", "chronyd"}...)
 	fmt.Println(s, e, errorCode)
-	Expect(errorCode).To(Equal(0))
+	Expect(errorCode).To(Equal(0), "Failed to start chrony daemon")
 }

--- a/subsystem/utils.go
+++ b/subsystem/utils.go
@@ -459,16 +459,16 @@ func stopAgent() error {
 }
 
 func startContainer(args ...string) error {
-	args = append([]string{"-f", "docker-compose.yml", "up", "-d"}, args...)
+	args = append([]string{"compose", "-f", "docker-compose.yml", "up", "-d"}, args...)
 
-	cmd := exec.Command("docker-compose", args...)
+	cmd := exec.Command("docker", args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd.Run()
 }
 
 func stopContainer(name string) error {
-	cmd := exec.Command("docker-compose", "-f", "docker-compose.yml", "rm", "-s", "-f", name)
+	cmd := exec.Command("docker", "compose", "-f", "docker-compose.yml", "rm", "-s", "-f", name)
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }


### PR DESCRIPTION
Replace base golang image in the build Dockerfile as it is based on centos7 and it is EOL, which results in yum can't reach its repositories