### PR TITLE
NO-ISSUE: Align build dockerfile to use go-toolset for go & centos9 for dep

### DIFF
--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -1,21 +1,9 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS golang
 
-USER 0
+ENV GOPATH=/opt/app-root/src/go
+RUN mkdir -p ${GOPATH}/bin
 
-ENV GOFLAGS=""
-ENV GOPATH="/go"
-ENV PATH="$PATH:$GOPATH/bin"
-
-RUN dnf install -y 'dnf-command(config-manager)' && \
-    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
-    dnf install -y \
-        docker-ce \
-        docker-ce-cli \
-        containerd.io \
-        docker-compose-plugin \
-    && dnf clean all
-
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.53.2
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.53.2
 RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
     go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
     go install github.com/golang/mock/mockgen@v1.6.0 && \
@@ -24,5 +12,26 @@ RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
     go install github.com/axw/gocov/gocov@latest && \
     go install github.com/AlekSi/gocov-xml@latest
 
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-compose-plugin \
+        make \
+        git \
+        util-linux \
+    && dnf clean all
+
 # required due to issue https://github.com/docker/compose/issues/4060
 ENV LANG=en_US.UTF-8
+
+ENV GOROOT=/usr/lib/golang
+ENV GOPATH=/go
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+COPY --from=golang /opt/app-root/src/go $GOPATH
+COPY --from=golang $GOROOT $GOROOT


### PR DESCRIPTION
Second round of CI adjustment https://github.com/openshift/assisted-installer-agent/pull/735

This time, trying to align our build dockerfile on the same logic across our repo

/cc @danmanor 