### PR TITLE
[release-ocm-2.9] MGMT-18332: Use centos stream 9 as the base image for test container

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,7 +62,7 @@ linters:
     - megacheck
     - unconvert
     - goimports
-    - scopelint
+    - exportloopref
 
 linters-settings:
   govet:

--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -1,14 +1,36 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
-ENV GO111MODULE=on
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 AS golang
+
 ENV GOFLAGS=""
 
-RUN yum install -y docker docker-compose && \
-    yum clean all
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.56.1
-RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
-    go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
-    go install github.com/golang/mock/mockgen@v1.6.0 && \
-    go install github.com/vektra/mockery/v2@v2.9.6 && \
-    go install gotest.tools/gotestsum@v1.6.3 && \
-    go install github.com/axw/gocov/gocov@latest && \
-    go install github.com/AlekSi/gocov-xml@latest
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.56.0 && \
+        go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
+        go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
+        go install github.com/golang/mock/mockgen@v1.6.0 && \
+        go install github.com/vektra/mockery/v2@v2.9.6 && \
+        go install gotest.tools/gotestsum@v1.6.3 && \
+        go install github.com/axw/gocov/gocov@latest && \
+        go install github.com/AlekSi/gocov-xml@latest
+
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-compose-plugin \
+        make \
+        git \
+        openssl-devel \
+        gcc \
+    && dnf clean all
+
+ENV GOROOT=/usr/lib/golang
+ENV GOPATH=/opt/app-root/src/go
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+COPY --from=golang $GOPATH $GOPATH
+COPY --from=golang $GOROOT $GOROOT
+
+RUN chmod 775 -R $GOPATH && chmod 775 -R $GOROOT

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo
 GIT_REVISION := $(shell git rev-parse HEAD)
 CONTAINER_BUILD_PARAMS = --network=host --label git_revision=${GIT_REVISION} ${CONTAINER_BUILD_EXTRA_PARAMS}
 
-DOCKER_COMPOSE=docker-compose -f ./subsystem/docker-compose.yml
+DOCKER_COMPOSE=docker compose -f ./subsystem/docker-compose.yml
 
 all: build
 

--- a/subsystem/utils.go
+++ b/subsystem/utils.go
@@ -459,16 +459,16 @@ func stopAgent() error {
 }
 
 func startContainer(args ...string) error {
-	args = append([]string{"-f", "docker-compose.yml", "up", "-d"}, args...)
+	args = append([]string{"compose", "-f", "docker-compose.yml", "up", "-d"}, args...)
 
-	cmd := exec.Command("docker-compose", args...)
+	cmd := exec.Command("docker", args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd.Run()
 }
 
 func stopContainer(name string) error {
-	cmd := exec.Command("docker-compose", "-f", "docker-compose.yml", "rm", "-s", "-f", name)
+	cmd := exec.Command("docker", "compose", "-f", "docker-compose.yml", "rm", "-s", "-f", name)
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }


### PR DESCRIPTION
- Use centos stream 9 as the base image for test container
- Replace golang base image as it is based on centos linux 7 (EOL)
- Replace deprecated scopelint