### PR TITLE
MGMT-18332: Use centos stream 9 as the base image for test container

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,7 +62,7 @@ linters:
     - megacheck
     - unconvert
     - goimports
-    - scopelint
+    - exportloopref
 
 linters-settings:
   govet:

--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -1,10 +1,17 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20
-
-USER 0
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 AS golang
 
 ENV GOFLAGS=""
-ENV GOPATH="/go"
-ENV PATH="$PATH:$GOPATH/bin"
+
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.56.0 && \
+        go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
+        go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
+        go install github.com/golang/mock/mockgen@v1.6.0 && \
+        go install github.com/vektra/mockery/v2@v2.9.6 && \
+        go install gotest.tools/gotestsum@v1.6.3 && \
+        go install github.com/axw/gocov/gocov@latest && \
+        go install github.com/AlekSi/gocov-xml@latest
+
+FROM quay.io/centos/centos:stream9
 
 RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
@@ -13,16 +20,19 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         docker-ce-cli \
         containerd.io \
         docker-compose-plugin \
+        make \
+        git \
+        openssl-devel \
+        gcc \
     && dnf clean all
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.53.2
-RUN go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
-    go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
-    go install github.com/golang/mock/mockgen@v1.6.0 && \
-    go install github.com/vektra/mockery/v2@v2.9.6 && \
-    go install gotest.tools/gotestsum@v1.6.3 && \
-    go install github.com/axw/gocov/gocov@latest && \
-    go install github.com/AlekSi/gocov-xml@latest
-
+ENV GOROOT=/usr/lib/golang
+ENV GOPATH=/opt/app-root/src/go
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 # required due to issue https://github.com/docker/compose/issues/4060
 ENV LANG=en_US.UTF-8
+
+COPY --from=golang $GOPATH $GOPATH
+COPY --from=golang $GOROOT $GOROOT
+
+RUN chmod 775 -R $GOPATH && chmod 775 -R $GOROOT


### PR DESCRIPTION
- Use centos stream 9 as the base image for test container
- Replace deprecated scopelint linter