### PR TITLE
[release-ocm-2.9] MGMT-18313: Replace golang base image as it is based on Centos Linux 7

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -1,4 +1,7 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 AS builder
+
+USER 0
+
 ARG TARGETPLATFORM
 ENV GO111MODULE=on
 ENV GOFLAGS=""
@@ -12,11 +15,8 @@ COPY . .
 
 RUN TARGETPLATFORM=$TARGETPLATFORM make build
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-    
 ARG TARGETPLATFORM
 RUN if [[ "$TARGETPLATFORM" == "linux/amd64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y biosdevname dmidecode ; fi
 RUN if [[ "$TARGETPLATFORM" == "linux/arm64" || -z "$TARGETPLATFORM" ]] ; then  dnf install -y dmidecode ; fi
@@ -25,8 +25,7 @@ RUN dnf install --setopt=install_weak_deps=False --setopt=tsdocs=False -y \
 		findutils iputils \
 		podman \
 		# inventory
-		ipmitool file fio \
-		sg3_utils \
+		ipmitool file fio sg3_utils \
 		# free_addresses
 		nmap \
 		# dhcp_lease_allocate
@@ -35,6 +34,8 @@ RUN dnf install --setopt=install_weak_deps=False --setopt=tsdocs=False -y \
 		tar openssh-clients \
 		# ntp_synchronizer
 		chrony \
+		# for the 'nsenter' executable
+		util-linux-core \
 		&& dnf update --setopt=install_weak_deps=False --setopt=tsdocs=False -y systemd && dnf clean all && rm -rf /var/cache
 
 COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/build/agent /usr/bin/agent

--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -29,6 +29,8 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
 ENV GOROOT=/usr/lib/golang
 ENV GOPATH=/opt/app-root/src/go
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+# required due to issue https://github.com/docker/compose/issues/4060
+ENV LANG=en_US.UTF-8
 
 COPY --from=golang $GOPATH $GOPATH
 COPY --from=golang $GOROOT $GOROOT

--- a/subsystem/Dockerfile.agent_test
+++ b/subsystem/Dockerfile.agent_test
@@ -1,15 +1,15 @@
 ARG ASSISTED_INSTALLER_AGENT=quay.io/edge-infrastructure/assisted-installer-agent:latest
 FROM $ASSISTED_INSTALLER_AGENT
 
-RUN yum install -y yum-utils \
-    && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
-    && dnf install -y --nobest --allowerasing \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    tcpdump \
-    procps \
-    python39 \
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y --nobest --allowerasing \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        tcpdump \
+        procps \
+        python39 \
     && dnf clean all
 
 RUN echo -e "#!/bin/sh \nshift 7 && \$@" > /usr/bin/nsenter && chmod a+x /usr/bin/nsenter

--- a/subsystem/lease_test.go
+++ b/subsystem/lease_test.go
@@ -238,7 +238,7 @@ func startTcpDump(output chan string, ifaceName string, timeoutSecs, count int) 
 	if count > 0 {
 		countStr = fmt.Sprintf("-c %d", count)
 	}
-	dump := fmt.Sprintf("timeout %d tcpdump -l -i %s %s -v 'udp dst port 67' | awk '/DHCP-Message Option 53/{print $6}'", timeoutSecs, ifaceName, countStr)
+	dump := fmt.Sprintf("timeout %d tcpdump -l -i %s %s -v 'udp dst port 67' | awk '/DHCP-Message \\(53\\)/{print $5}'", timeoutSecs, ifaceName, countStr)
 
 	s, e, errorCode := agentUtils.Execute("docker", []string{"exec", "agent", "bash", "-c", dump}...)
 	fmt.Println(s, e, errorCode)


### PR DESCRIPTION
This PR moves centos base image from stream8 to stream 9 as well as stream8 is EOL