### PR TITLE
MGMT-17103: Fixing boot issue for IBMZ hosts in reclaim

### DIFF
--- a/src/commands/actions/download_boot_artifacts_cmd.go
+++ b/src/commands/actions/download_boot_artifacts_cmd.go
@@ -50,7 +50,7 @@ const (
 	bootLoaderConfigFileName string = "/00-assisted-discovery.conf"
 	bootLoaderConfigTemplate string = `title Assisted Installer Discovery
 version 999
-options random.trust_cpu=on ignition.firstboot ignition.platform.id=metal 'coreos.live.rootfs_url=%s'
+options random.trust_cpu=on ignition.firstboot ignition.platform.id=metal coreos.live.rootfs_url=%s
 linux %s
 initrd %s`
 )

--- a/src/commands/actions/download_boot_artifacts_cmd.go
+++ b/src/commands/actions/download_boot_artifacts_cmd.go
@@ -9,11 +9,10 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"runtime"
 	"syscall"
 
 	"github.com/openshift/assisted-installer-agent/src/config"
-	inv "github.com/openshift/assisted-installer-agent/src/inventory"
-	"github.com/openshift/assisted-installer-agent/src/util"
 	"github.com/openshift/assisted-service/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -149,10 +148,8 @@ func createBootLoaderConfig(rootfsUrl, artifactsPath, bootLoaderPath string) err
 	initrdPath := path.Join(artifactsPath, initrdFile)
 	bootLoaderConfigFile := path.Join(bootLoaderPath, bootLoaderConfigFileName)
 	var bootLoaderConfig string
-	dependencies := &util.Dependencies{}
-	cpuInfo := inv.GetCPU(dependencies)
 	bootLoaderConfig = fmt.Sprintf(bootLoaderConfigTemplate, rootfsUrl, kernelPath, initrdPath)
-	if cpuInfo.Architecture == "s390x" {
+	if runtime.GOARCH == "s390x" {
 		bootLoaderConfig = fmt.Sprintf(bootLoaderConfigTemplateS390x, rootfsUrl, kernelPath, initrdPath)
 	}
 

--- a/src/commands/actions/reboot_for_reclaim.go
+++ b/src/commands/actions/reboot_for_reclaim.go
@@ -3,9 +3,9 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"syscall"
 
-	inv "github.com/openshift/assisted-installer-agent/src/inventory"
 	"github.com/openshift/assisted-installer-agent/src/util"
 	"github.com/openshift/assisted-service/models"
 )
@@ -27,9 +27,8 @@ func (a *rebootForReclaim) Run() (stdout, stderr string, exitCode int) {
 	if err := syscall.Chroot(*req.HostFsMountDir); err != nil {
 		return "", err.Error(), -1
 	}
-	dependencies := &util.Dependencies{}
-	cpuInfo := inv.GetCPU(dependencies)
-	if cpuInfo.Architecture == "s390x" {
+
+	if runtime.GOARCH == "s390x" {
 		unshareCommand := "unshare"
 		unshareArgs := []string{
 			"--mount",


### PR DESCRIPTION
Fixing boot issue for Z hosts in reclaim
- Removed single quotes for coreos.live.rootfs_url in bootLoaderConfigTemplate
- Added zipl incase of s390x for handling boot issue in reclaiming agents (HCP)

