### PR TITLE
MGMT-18466: improve depndabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,12 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "approved"
       - "lgtm"
@@ -17,7 +16,10 @@ updates:
     commit-message:
       prefix: "NO-ISSUE"
     groups:
+      go-security-dependencies:
+        applies-to: security-updates
+        patterns:
+          - "*"
       go-dependencies:
         patterns:
           - "*"
-


### PR DESCRIPTION
- Improve dependabot groups.
Allowing security update in a separate group give us smaller change ( minor version change ) which will be easier to auto merge.