### PR TITLE
[release-ocm-2.11] MGMT-18839: Retry downloading boot artifacts (#778)

### DIFF
--- a/src/commands/actions/download_boot_artifacts_cmd.go
+++ b/src/commands/actions/download_boot_artifacts_cmd.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"syscall"
+	"time"
 
 	"github.com/openshift/assisted-installer-agent/src/config"
 	"github.com/openshift/assisted-service/models"
@@ -44,11 +45,13 @@ func (a *downloadBootArtifacts) Args() []string {
 }
 
 const (
-	artifactsFolder          string = "/boot/discovery"
-	kernelFile               string = "vmlinuz"
-	initrdFile               string = "initrd"
-	bootLoaderConfigFileName string = "/00-assisted-discovery.conf"
-	bootLoaderConfigTemplate string = `title Assisted Installer Discovery
+	retryDownloadAmount              = 5
+	defaultDownloadRetryDelay        = 1 * time.Minute
+	artifactsFolder           string = "/boot/discovery"
+	kernelFile                string = "vmlinuz"
+	initrdFile                string = "initrd"
+	bootLoaderConfigFileName  string = "/00-assisted-discovery.conf"
+	bootLoaderConfigTemplate  string = `title Assisted Installer Discovery
 version 999
 options random.trust_cpu=on ignition.firstboot ignition.platform.id=metal 'coreos.live.rootfs_url=%s'
 linux %s
@@ -77,11 +80,11 @@ func run(infraEnvId, downloaderRequestStr, caCertPath string) error {
 		return fmt.Errorf("failed creating secure assisted service client: %w", err)
 	}
 
-	if err := download(httpClient, path.Join(hostArtifactsFolder, kernelFile), *req.KernelURL); err != nil {
+	if err := download(httpClient, path.Join(hostArtifactsFolder, kernelFile), *req.KernelURL, retryDownloadAmount); err != nil {
 		return fmt.Errorf("failed downloading kernel to host: %w", err)
 	}
 
-	if err := download(httpClient, path.Join(hostArtifactsFolder, initrdFile), *req.InitrdURL); err != nil {
+	if err := download(httpClient, path.Join(hostArtifactsFolder, initrdFile), *req.InitrdURL, retryDownloadAmount); err != nil {
 		return fmt.Errorf("failed downloading initrd to host: %w", err)
 	}
 
@@ -116,20 +119,29 @@ func createHTTPClient(caCertPath string) (*http.Client, error) {
 	return client, nil
 }
 
-func download(httpClient *http.Client, filePath, url string) error {
-	res, err := httpClient.Get(url)
-	if err != nil {
-		return fmt.Errorf("failed getting %s: %w", url, err)
+func download(httpClient *http.Client, filePath, url string, retry int) error {
+	var downloadErr error
+	var res *http.Response
+	for attempts := 0; attempts < retry; attempts++ {
+		res, downloadErr = httpClient.Get(url)
+		if downloadErr == nil && (res.StatusCode >= 200 && res.StatusCode < 300) {
+			break
+		}
+		downloadErr = fmt.Errorf("failed downloading boot artifact from %s, status code received: %d, attempt %d/%d, download error: %w",
+			url, res.StatusCode, attempts, retry, downloadErr)
+		log.Warn(downloadErr.Error())
+		time.Sleep(defaultDownloadRetryDelay)
+	}
+
+	if downloadErr != nil {
+		return fmt.Errorf("failed getting %s: %w", url, downloadErr)
 	}
 	defer res.Body.Close()
+
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read body while getting url %s: %w", url, err)
 	}
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return fmt.Errorf("failed getting %s, status code received: %d\nBody received: %s", url, res.StatusCode, body)
-	}
-
 	err = os.WriteFile(filePath, body, 0644) //nolint:gosec
 	if err != nil {
 		return fmt.Errorf("failed writing file %s: %w", filePath, err)


### PR DESCRIPTION
Cherry-pick of PR https://github.com/openshift/assisted-installer-agent/pull/778
/cc @gamli75 

---
Adds a retry when downloading the boot artifacts from assisted service in case there are connection issues or a server disruption.

