### PR TITLE
ACM-15078: Fixing agents reuse problem in z/VM after reclaim

### DIFF
--- a/src/commands/actions/download_boot_artifacts_cmd.go
+++ b/src/commands/actions/download_boot_artifacts_cmd.go
@@ -54,7 +54,7 @@ const (
 	bootLoaderConfigFileName      string = "/00-assisted-discovery.conf"
 	bootLoaderConfigTemplateS390x string = `title Assisted Installer Discovery
 version 999
-options random.trust_cpu=on ignition.firstboot ignition.platform.id=metal coreos.live.rootfs_url=%s
+options random.trust_cpu=on ai.ip_cfg_override=1 ignition.firstboot ignition.platform.id=metal coreos.live.rootfs_url=%s
 linux %s
 initrd %s`
 	bootLoaderConfigTemplate string = `title Assisted Installer Discovery

--- a/src/commands/actions/reboot_for_reclaim.go
+++ b/src/commands/actions/reboot_for_reclaim.go
@@ -3,7 +3,9 @@ package actions
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/openshift/assisted-installer-agent/src/util"
@@ -29,21 +31,64 @@ func (a *rebootForReclaim) Run() (stdout, stderr string, exitCode int) {
 	}
 
 	if runtime.GOARCH == "s390x" {
+		var options string
+		cmdline_params := make(map[string]string)
+		var requiredCmdline string
+
+		stdout, stderr, exitCode = util.Execute("cat", "/boot/loader/entries/00-assisted-discovery.conf")
+		if exitCode != 0 {
+			return stdout, stderr, exitCode
+		}
+		lines := strings.Split(stdout, "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "options") {
+				options = strings.TrimSpace(strings.TrimPrefix(line, "options"))
+				break
+			}
+		}
+		stdout, stderr, exitCode := util.Execute("cat", "/proc/cmdline")
+		if exitCode != 0 {
+			return stdout, stderr, exitCode
+		}
+
+		// Parameters to extract from cmdline for agents
+		paramsToExtract := []string{
+			"ip",
+			"nameserver",
+			"rd.znet",
+			"zfcp.allow_lun_scan",
+			"rd.zfcp",
+			"rd.dasd",
+		}
+
+		for _, param := range paramsToExtract {
+			regex := regexp.MustCompile(fmt.Sprintf(`\b%s=([^\s]+)`, param))
+			match := regex.FindStringSubmatch(stdout)
+			if len(match) > 1 {
+				cmdline_params[param] = match[1]
+			}
+		}
+
+		for key, value := range cmdline_params {
+			requiredCmdline += fmt.Sprintf("%s=%s ", key, value)
+		}
+
 		unshareCommand := "unshare"
 		unshareArgs := []string{
 			"--mount",
 			"bash",
 			"-c",
-			fmt.Sprintf("mount -o remount,rw /boot && zipl -V -t /boot -i %s/%s -r %s/%s -c /boot/loader/entries%s -p /boot/loader/entries%s",
+			fmt.Sprintf("mount -o remount,rw /boot && zipl -V -t /boot -i %s/%s -r %s/%s -P '%s %s'",
 				artifactsFolder, kernelFile,
 				artifactsFolder, initrdFile,
-				bootLoaderConfigFileName,
-				bootLoaderConfigFileName),
+				options,
+				requiredCmdline),
 		}
 		stdout, stderr, exitCode = util.Execute(unshareCommand, unshareArgs...)
 		if exitCode != 0 {
 			return stdout, stderr, exitCode
 		}
+
 	}
 	return util.Execute("systemctl", "reboot")
 }

--- a/src/commands/actions/reboot_for_reclaim_test.go
+++ b/src/commands/actions/reboot_for_reclaim_test.go
@@ -21,4 +21,25 @@ var _ = Describe("reboot_for_reclaim", func() {
 	It("fails when given bad input", func() {
 		badParamsCommonTests(models.StepTypeRebootForReclaim, []string{})
 	})
+
+	Context("extractCmdlineParams", func() {
+		It("returns the expected parameters when valid cmdline output is given", func() {
+			cmdlineOutput := "ip=192.168.1.1 nameserver=8.8.8.8 rd.znet=enabled zfcp.allow_lun_scan=0 rd.zfcp=xyz rd.dasd=abc"
+			paramsToExtract := []string{"ip", "nameserver", "rd.znet", "zfcp.allow_lun_scan", "rd.zfcp", "rd.dasd"}
+
+			expectedCmdline := "ip=192.168.1.1 nameserver=8.8.8.8 rd.znet=enabled zfcp.allow_lun_scan=0 rd.zfcp=xyz rd.dasd=abc "
+			requiredCmdline := extractCmdlineParams(cmdlineOutput, paramsToExtract)
+
+			Expect(requiredCmdline).To(Equal(expectedCmdline))
+		})
+
+		It("returns an empty string when no parameters match", func() {
+			cmdlineOutput := "other_param=value"
+			paramsToExtract := []string{"ip", "nameserver"}
+
+			requiredCmdline := extractCmdlineParams(cmdlineOutput, paramsToExtract)
+
+			Expect(requiredCmdline).To(Equal(""))
+		})
+	})
 })


### PR DESCRIPTION
- Updated bootLoaderConfigTemplateS390x to add ai.ip_cfg_override to take care of IP and nameserver parameters , which is a mandatory parameter in z/VM as mac address is not persistent. 
- Updated paramaters which are being passed to zipl , to include parameters from /proc/cmdline which will help in reusing the agents after reclaim.