### PR TITLE
MGMT-19166:  Implement MTU checker

### DIFF
--- a/src/connectivity_check/connectivity_check.go
+++ b/src/connectivity_check/connectivity_check.go
@@ -24,6 +24,7 @@ func (c *connectivity) checkers() []Checker {
 			&pingChecker{executer: e},
 			&arpingChecker{executer: e},
 			&nmapChecker{executer: e},
+			&mtuChecker{executer: e},
 		}
 	}
 }

--- a/src/connectivity_check/connectivity_runner.go
+++ b/src/connectivity_check/connectivity_runner.go
@@ -1,6 +1,7 @@
 package connectivity_check
 
 import (
+	"net"
 	"sort"
 	"sync"
 
@@ -18,9 +19,11 @@ const (
 )
 
 type OutgoingNic struct {
+	MTU              int
 	Name             string
 	HasIpv4Addresses bool
 	HasIpv6Addresses bool
+	Addresses        []net.Addr
 }
 
 // Attributes to be sent to a checker in order to perform a single checking operation

--- a/src/connectivity_check/mtu_checker.go
+++ b/src/connectivity_check/mtu_checker.go
@@ -1,0 +1,95 @@
+package connectivity_check
+
+import (
+	"net"
+	"sort"
+	"strconv"
+
+	"github.com/openshift/assisted-service/models"
+	log "github.com/sirupsen/logrus"
+)
+
+// Since the exact headers in use are uncertain, the total overhead is estimated to be a maximum of ~100 bytes.
+// This includes 18 bytes for VLAN, a maximum of 60 bytes for IPv4/IPv6, 8 bytes for ICMP, and potential additional headers.
+// To be on the safe side, we assume an overhead of 150 bytes.
+const headers = 150
+
+type mtuChecker struct {
+	executer Executer
+}
+
+func (m *mtuChecker) Features() Features {
+	return OutgoingNicFeature
+}
+
+func (m *mtuChecker) Check(attributes Attributes) ResultReporter {
+	ret := models.MtuReport{
+		RemoteIPAddress: attributes.RemoteIPAddress,
+		OutgoingNic:     attributes.OutgoingNIC.Name,
+	}
+
+	// Check if the remote IP address is IPv4 or IPv6
+	remoteIP := net.ParseIP(attributes.RemoteIPAddress)
+	if remoteIP == nil {
+		log.Errorf("MTU checker: Invalid remote IP address %s", attributes.RemoteIPAddress)
+		return newMtuResultReporter(&ret)
+	}
+	isRemoteIPv6 := remoteIP.To4() == nil // If To4() is nil, it's IPv6
+
+	var localIP string
+
+	for _, addr := range attributes.OutgoingNIC.Addresses {
+		ipN, ok := addr.(*net.IPNet)
+		if !ok {
+			log.Errorf("MTU checker: failed convert address %v", addr)
+			return newMtuResultReporter(&ret)
+		}
+
+		localIP = ipN.IP.String()
+
+		// Check if the local IP address is IPv4 or IPv6
+		isLocalIPv6 := ipN.IP.To4() == nil // If To4() is nil, it's IPv6
+		if isLocalIPv6 != isRemoteIPv6 {
+			continue
+		}
+
+		mtu := attributes.OutgoingNIC.MTU
+		sizeWithoutHeaders := mtu - headers
+
+		// Perform an initial ping without specifying the MTU to rule out the possibility of failure due to issues unrelated to MTU.
+		_, err := m.executer.Execute("ping", attributes.RemoteIPAddress, "-c", "3", "-I", attributes.OutgoingNIC.Name)
+		if err != nil {
+			log.WithError(err).Errorf("MTU checker: failed first ping. Remote address: %s, nic: %s, local address: %s", attributes.RemoteIPAddress, attributes.OutgoingNIC.Name, localIP)
+			return nil
+		}
+
+		// Second ping with MTU
+		_, err = m.executer.Execute("ping", attributes.RemoteIPAddress, "-c", "3", "-M", "do", "-s", strconv.Itoa(sizeWithoutHeaders), "-I", attributes.OutgoingNIC.Name)
+		if err != nil {
+			log.WithError(err).Errorf("MTU checker: failed to ping address %s nic %s mtu %d", attributes.RemoteIPAddress, attributes.OutgoingNIC.Name, mtu)
+			return newMtuResultReporter(&ret)
+		}
+	}
+	ret.MtuSuccessful = true
+	return newMtuResultReporter(&ret)
+}
+
+func (m *mtuChecker) Finalize(resultingHost *models.ConnectivityRemoteHost) {
+	sort.SliceStable(resultingHost.MtuReport,
+		func(i, j int) bool {
+			return resultingHost.MtuReport[i].RemoteIPAddress < resultingHost.MtuReport[j].RemoteIPAddress
+		})
+}
+
+type mtuResult struct {
+	mtuReport *models.MtuReport
+}
+
+func (m *mtuResult) Report(resultingHost *models.ConnectivityRemoteHost) error {
+	resultingHost.MtuReport = append(resultingHost.MtuReport, m.mtuReport)
+	return nil
+}
+
+func newMtuResultReporter(mtuReport *models.MtuReport) ResultReporter {
+	return &mtuResult{mtuReport: mtuReport}
+}

--- a/src/connectivity_check/mtu_checker_test.go
+++ b/src/connectivity_check/mtu_checker_test.go
@@ -1,0 +1,133 @@
+package connectivity_check
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("MTU checker", func() {
+	const (
+		remoteIPv4Address         = "192.168.127.31"
+		remoteIPv6Address         = "3001:db9::22"
+		outgoingIPv4Address       = "192.168.127.30"
+		outgoingIPv6Address       = "3001:db9::1f"
+		outgoingNIC               = "ens3"
+		bigSize                   = 9000
+		regularSize               = 1500
+		bigSizeWithoutHeaders     = bigSize - headers
+		regularSizeWithoutHeaders = regularSize - headers
+	)
+
+	var (
+		checker      Checker
+		mockExecuter *MockExecuter
+	)
+
+	mockSuccessPingWithoutSize := func(remoteIPAddress string) {
+		mockExecuter.On("Execute", "ping", remoteIPAddress, "-c", "3", "-I", outgoingNIC).
+			Return("success output", nil).Once()
+	}
+
+	mockSuccessPingWithSize := func(remoteIPAddress string) {
+		mockExecuter.On("Execute", "ping", remoteIPAddress, "-c", "3", "-M", "do", "-s", strconv.Itoa(regularSizeWithoutHeaders), "-I", outgoingNIC).
+			Return("success output", nil).Once()
+	}
+
+	mockFailPingWithSize := func(remoteIPAddress string) {
+		mockExecuter.On("Execute", "ping", remoteIPAddress, "-c", "3", "-M", "do", "-s", strconv.Itoa(bigSizeWithoutHeaders), "-I", outgoingNIC).
+			Return("failure output", fmt.Errorf("some error")).Once()
+	}
+
+	BeforeEach(func() {
+		mockExecuter = &MockExecuter{}
+		checker = &mtuChecker{executer: mockExecuter}
+	})
+	AfterEach(func() {
+		mockExecuter.AssertExpectations(GinkgoT())
+	})
+	It("MTU Check Failure - IPv4", func() {
+
+		attributes := Attributes{
+			RemoteIPAddress: remoteIPv4Address,
+			OutgoingNIC: OutgoingNic{Name: outgoingNIC, MTU: 9000, Addresses: []net.Addr{&net.IPNet{
+				IP:   net.ParseIP(outgoingIPv4Address),
+				Mask: net.CIDRMask(24, 32),
+			}}},
+		}
+		mockSuccessPingWithoutSize(remoteIPv4Address)
+		mockFailPingWithSize(remoteIPv4Address)
+		reporter := checker.Check(attributes)
+		Expect(reporter).ToNot(BeNil())
+		var resultingHost models.ConnectivityRemoteHost
+		Expect(reporter.Report(&resultingHost)).ToNot(HaveOccurred())
+		Expect(resultingHost.MtuReport).To(HaveLen(1))
+		Expect(resultingHost.MtuReport[0].RemoteIPAddress).To(Equal(remoteIPv4Address))
+		Expect(resultingHost.MtuReport[0].OutgoingNic).To(Equal(outgoingNIC))
+		Expect(resultingHost.MtuReport[0].MtuSuccessful).To(BeFalse())
+	})
+	It("MTU Check Failure - IPv6", func() {
+
+		attributes := Attributes{
+			RemoteIPAddress: remoteIPv6Address,
+			OutgoingNIC: OutgoingNic{Name: outgoingNIC, MTU: 9000, Addresses: []net.Addr{&net.IPNet{
+				IP:   net.ParseIP(outgoingIPv6Address),
+				Mask: net.CIDRMask(64, 128),
+			}}},
+		}
+		mockSuccessPingWithoutSize(remoteIPv6Address)
+		mockFailPingWithSize(remoteIPv6Address)
+		reporter := checker.Check(attributes)
+		Expect(reporter).ToNot(BeNil())
+		var resultingHost models.ConnectivityRemoteHost
+		Expect(reporter.Report(&resultingHost)).ToNot(HaveOccurred())
+		Expect(resultingHost.MtuReport).To(HaveLen(1))
+		Expect(resultingHost.MtuReport[0].RemoteIPAddress).To(Equal(remoteIPv6Address))
+		Expect(resultingHost.MtuReport[0].OutgoingNic).To(Equal(outgoingNIC))
+		Expect(resultingHost.MtuReport[0].MtuSuccessful).To(BeFalse())
+	})
+	It("MTU Check Success - IPv4", func() {
+
+		attributes := Attributes{
+			RemoteIPAddress: remoteIPv4Address,
+			OutgoingNIC: OutgoingNic{Name: outgoingNIC, MTU: 1500, Addresses: []net.Addr{&net.IPNet{
+				IP:   net.ParseIP(outgoingIPv4Address),
+				Mask: net.CIDRMask(24, 32),
+			}}},
+		}
+		mockSuccessPingWithoutSize(remoteIPv4Address)
+		mockSuccessPingWithSize(remoteIPv4Address)
+		reporter := checker.Check(attributes)
+		Expect(reporter).ToNot(BeNil())
+		var resultingHost models.ConnectivityRemoteHost
+		Expect(reporter.Report(&resultingHost)).ToNot(HaveOccurred())
+		Expect(resultingHost.MtuReport).To(HaveLen(1))
+		Expect(resultingHost.MtuReport[0].RemoteIPAddress).To(Equal(remoteIPv4Address))
+		Expect(resultingHost.MtuReport[0].OutgoingNic).To(Equal(outgoingNIC))
+		Expect(resultingHost.MtuReport[0].MtuSuccessful).To(BeTrue())
+	})
+	It("MTU Check Success - IPv6", func() {
+
+		attributes := Attributes{
+			RemoteIPAddress: remoteIPv6Address,
+			OutgoingNIC: OutgoingNic{Name: outgoingNIC, MTU: 1500, Addresses: []net.Addr{&net.IPNet{
+				IP:   net.ParseIP(outgoingIPv6Address),
+				Mask: net.CIDRMask(64, 128),
+			}}},
+		}
+		mockSuccessPingWithoutSize(remoteIPv6Address)
+		mockSuccessPingWithSize(remoteIPv6Address)
+		reporter := checker.Check(attributes)
+		Expect(reporter).ToNot(BeNil())
+		var resultingHost models.ConnectivityRemoteHost
+		Expect(reporter.Report(&resultingHost)).ToNot(HaveOccurred())
+		Expect(resultingHost.MtuReport).To(HaveLen(1))
+		Expect(resultingHost.MtuReport[0].RemoteIPAddress).To(Equal(remoteIPv6Address))
+		Expect(resultingHost.MtuReport[0].OutgoingNic).To(Equal(outgoingNIC))
+		Expect(resultingHost.MtuReport[0].MtuSuccessful).To(BeTrue())
+	})
+})

--- a/src/connectivity_check/util.go
+++ b/src/connectivity_check/util.go
@@ -73,7 +73,7 @@ func getOutgoingNics(dryRunConfig *config.DryRunConfig, d util.IDependencies) []
 		// NICs those interfaces that have at least one IP address assigned.
 		addrs, _ := intf.Addrs()
 
-		outgoingNic := OutgoingNic{Name: intf.Name()}
+		outgoingNic := OutgoingNic{Name: intf.Name(), MTU: intf.MTU()}
 		for _, addr := range addrs {
 			isIpv4, isLinkLocal, err := analyzeAddress(addr)
 			if err != nil {
@@ -93,6 +93,7 @@ func getOutgoingNics(dryRunConfig *config.DryRunConfig, d util.IDependencies) []
 			log.Infof("Skipping NIC %s (MAC %s) because of no valid addresses", intf.Name(), intf.HardwareAddr().String())
 			continue
 		}
+		outgoingNic.Addresses = addrs
 		ret = append(ret, outgoingNic)
 	}
 	return ret

--- a/src/connectivity_check/util_test.go
+++ b/src/connectivity_check/util_test.go
@@ -26,21 +26,29 @@ var _ = Describe("get outgoing nics", func() {
 			100, "physical")}, nil)
 		outgoingNics := getOutgoingNics(nil, d)
 		Expect(outgoingNics).To(HaveLen(1))
-		Expect(outgoingNics[0]).To(Equal(OutgoingNic{Name: "eth0", HasIpv4Addresses: true}))
+		Expect(outgoingNics[0].Name).To(Equal("eth0"))
+		Expect(outgoingNics[0].HasIpv4Addresses).To(Equal(true))
+		Expect(outgoingNics[0].Addresses[0].String()).To(Equal("1.2.3.4/24"))
 	})
 	It("ipv6", func() {
 		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{"2003::10/64"},
 			100, "physical")}, nil)
 		outgoingNics := getOutgoingNics(nil, d)
 		Expect(outgoingNics).To(HaveLen(1))
-		Expect(outgoingNics[0]).To(Equal(OutgoingNic{Name: "eth0", HasIpv6Addresses: true}))
+		Expect(outgoingNics[0].Name).To(Equal("eth0"))
+		Expect(outgoingNics[0].HasIpv6Addresses).To(Equal(true))
+		Expect(outgoingNics[0].Addresses[0].String()).To(Equal("2003::10/64"))
 	})
 	It("dual stack", func() {
 		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{"1.2.3.4/24",
 			"2003::10/64"}, 100, "physical")}, nil)
 		outgoingNics := getOutgoingNics(nil, d)
 		Expect(outgoingNics).To(HaveLen(1))
-		Expect(outgoingNics[0]).To(Equal(OutgoingNic{Name: "eth0", HasIpv4Addresses: true, HasIpv6Addresses: true}))
+		Expect(outgoingNics[0].Name).To(Equal("eth0"))
+		Expect(outgoingNics[0].HasIpv4Addresses).To(Equal(true))
+		Expect(outgoingNics[0].HasIpv6Addresses).To(Equal(true))
+		Expect(outgoingNics[0].Addresses[0].String()).To(Equal("1.2.3.4/24"))
+		Expect(outgoingNics[0].Addresses[1].String()).To(Equal("2003::10/64"))
 	})
 	It("ipv4 link local", func() {
 		d.On("Interfaces").Return([]util.Interface{util.NewFilledMockInterface(1500, "eth0", "f8:75:a4:a4:00:fe", net.FlagUp, []string{"169.254.0.5/16"},


### PR DESCRIPTION
As part of the MTU validation implementation, the agent will include the MTU checker in the connectivity check. It will send reports to the service if a ping with the specified MTU size fails.