### PR TITLE
MGMT-19390: Update mce's tekton pipelines to be multi-arch

### DIFF
--- a/.tekton/assisted-installer-agent-mce-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-agent-mce-downstream-main-pull-request.yaml
@@ -29,10 +29,17 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted_installer_agent-mce
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}}
+    - version={{revision}}
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/assisted-installer-agent-mce-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-agent-mce-downstream-main-push.yaml
@@ -26,10 +26,17 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted_installer_agent-mce
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}}
+    - version={{revision}}
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Update the tekton pipelines used to build mce downstream images to be multi-arch.

Part-of [MGMT-19390](https://issues.redhat.com//browse/MGMT-19390)