### PR TITLE
OCPBUGS-35716: expand unknown mb serials with "(none)"

### DIFF
--- a/src/scanners/machine_uuid_scanner.go
+++ b/src/scanners/machine_uuid_scanner.go
@@ -32,7 +32,7 @@ var (
 	FailureUUID = strfmt.UUID("deaddead-dead-dead-dead-deaddeaddead")
 )
 
-var unknownSerialCases = []string{"", util.UNKNOWN, "none",
+var unknownSerialCases = []string{"", util.UNKNOWN, "none", "(none)",
 	SerialUnspecifiedBaseBoardString, SerialUnspecifiedSystemString,
 	SerialDefaultString, SerialNotSpecified, strings.ToLower(SerialProliantGen11)}
 var unknownUuidCases = []string{"", util.UNKNOWN, ZeroesUUID, KaloomUUID}

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -65,6 +65,12 @@ var _ = Describe("Machine uuid test", func() {
 		id := ReadId(serialDiscovery, dependencies)
 		Expect(id).To(Equal(toUUID(TestUuid)))
 	})
+	It("System x3850 X5 (none) serial", func() {
+		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "(none)"}, nil).Once()
+		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
+		id := ReadId(serialDiscovery, dependencies)
+		Expect(id).To(Equal(toUUID(TestUuid)))
+	})
 
 	tests := []struct {
 		useCase  string


### PR DESCRIPTION
As mentioned in the bug, it seems it was reported for System x3850 X5 / x3950 X5 model 71455RG