### PR TITLE
MGMT-19507: Stop using multi-arch builds in konflux

### DIFF
--- a/.tekton/assisted-installer-agent-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-agent-downstream-main-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted_installer_agent-downstream
   - name: path-context

--- a/.tekton/assisted-installer-agent-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-agent-downstream-main-push.yaml
@@ -26,9 +26,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted_installer_agent-downstream
   - name: path-context

--- a/.tekton/assisted-installer-agent-mce-downstream-2-13-pull-request.yaml
+++ b/.tekton/assisted-installer-agent-mce-downstream-2-13-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted_installer_agent-mce
   - name: path-context

--- a/.tekton/assisted-installer-agent-mce-downstream-2-13-push.yaml
+++ b/.tekton/assisted-installer-agent-mce-downstream-2-13-push.yaml
@@ -26,9 +26,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted_installer_agent-mce
   - name: path-context

--- a/.tekton/assisted-installer-agent-mce-downstream-main-pull-request.yaml
+++ b/.tekton/assisted-installer-agent-mce-downstream-main-pull-request.yaml
@@ -29,9 +29,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted_installer_agent-mce
   - name: path-context

--- a/.tekton/assisted-installer-agent-mce-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-agent-mce-downstream-main-push.yaml
@@ -26,9 +26,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: Dockerfile.assisted_installer_agent-mce
   - name: path-context


### PR DESCRIPTION
A lot of time our pipelines as well as other teams' pipelines are stuck because they are unable to provision hosts with different architectures to build the images.
Because we currently don't use the multi-arch images we build with konflux, we will stop building multi-arch for now and readd those architectures when we need them.

Part-of [MGMT-19507](https://issues.redhat.com//browse/MGMT-19507)