### PR TITLE
OCPBUGS-45910: Fix cpu clockspeed for s390x

### DIFF
--- a/src/inventory/cpu.go
+++ b/src/inventory/cpu.go
@@ -43,11 +43,11 @@ func GetCPU(dependencies util.IDependencies) *models.CPU {
 		switch f.Field[:len(f.Field)-1] {
 		case "Architecture":
 			ret.Architecture = f.Data
-		case "Model name":
+		case "Model name", "Machine type":
 			ret.ModelName = f.Data
 		case "CPU(s)":
 			ret.Count, _ = strconv.ParseInt(f.Data, 10, 64)
-		case "CPU MHz", "CPU max MHz":
+		case "CPU MHz", "CPU max MHz", "CPU static MHz":
 			f, _ := strconv.ParseFloat(f.Data, 64)
 			ret.Frequency = max(ret.Frequency, f)
 		case "Flags":

--- a/src/inventory/cpu_test.go
+++ b/src/inventory/cpu_test.go
@@ -85,6 +85,49 @@ const (
       {"field":"Flags:", "data":"fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities"}
    ]
 }`
+
+	s390xLscpuOutput = `{
+   "lscpu": [
+      {"field":"Architecture:", "data":"s390x"},
+      {"field":"CPU op-mode(s):", "data":"32-bit, 64-bit"},
+      {"field":"Byte Order:", "data":"Big Endian"},
+      {"field":"CPU(s):", "data":"4"},
+      {"field":"On-line CPU(s) list:", "data":"0-3"},
+      {"field":"Vendor ID:", "data":"IBM/S390"},
+      {"field":"Machine type:", "data":"3931"},
+      {"field":"Thread(s) per core:", "data":"1"},
+      {"field":"Core(s) per socket:", "data":"1"},
+      {"field":"Socket(s):", "data":"1"},
+      {"field":"Book(s) per drawer:", "data":"1"},
+      {"field":"Drawer(s):", "data":"4"},
+      {"field":"CPU dynamic MHz:", "data":"5200"},
+      {"field":"CPU static MHz:", "data":"5200"},
+      {"field":"BogoMIPS:", "data":"26315.00"},
+      {"field":"Dispatching mode:", "data":"horizontal"},
+      {"field":"Flags:", "data":"esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te vx vxd vxe gs vxe2 vxp sort dflt vxp2 nnpa sie"},
+      {"field":"Hypervisor:", "data":"z/VM 7.3.0"},
+      {"field":"Hypervisor vendor:", "data":"IBM"},
+      {"field":"Virtualization type:", "data":"full"},
+      {"field":"L1d:", "data":"512 KiB (4 instances)"},
+      {"field":"L1i:", "data":"512 KiB (4 instances)"},
+      {"field":"L2:", "data":"32 MiB (1 instance)"},
+      {"field":"L3:", "data":"256 MiB"},
+      {"field":"NUMA node(s):", "data":"1"},
+      {"field":"NUMA node0 CPU(s):", "data":"0-3"},
+      {"field":"Gather data sampling:", "data":"Not affected"},
+      {"field":"Itlb multihit:", "data":"Not affected"},
+      {"field":"L1tf:", "data":"Not affected"},
+      {"field":"Mds:", "data":"Not affected"},
+      {"field":"Meltdown:", "data":"Not affected"},
+      {"field":"Mmio stale data:", "data":"Not affected"},
+      {"field":"Retbleed:", "data":"Not affected"},
+      {"field":"Spec store bypass:", "data":"Not affected"},
+      {"field":"Spectre v1:", "data":"Mitigation; __user pointer sanitization"},
+      {"field":"Spectre v2:", "data":"Mitigation; etokens"},
+      {"field":"Srbds:", "data":"Not affected"},
+      {"field":"Tsx async abort:", "data":"Not affected"}
+   ]
+}`
 )
 
 var _ = Describe("CPU test", func() {
@@ -127,6 +170,19 @@ var _ = Describe("CPU test", func() {
 				"arat", "pln", "pts", "hwp", "hwp_notify", "hwp_act_window", "hwp_epp", "md_clear", "flush_l1d", "arch_capabilities"},
 			Frequency: 4800,
 			ModelName: "Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz",
+		}
+		Expect(ret).To(Equal(&expected))
+	})
+	It("s390x OK", func() {
+		dependencies.On("Execute", "lscpu", "-J").Return(s390xLscpuOutput, "", 0).Once()
+		ret := GetCPU(dependencies)
+		expected := models.CPU{
+			Architecture: "s390x",
+			Count:        4,
+			Flags: []string{"esan3", "zarch", "stfle", "msa", "ldisp", "eimm", "dfp", "edat", "etf3eh", "highgprs", "te", "vx",
+				"vxd", "vxe", "gs", "vxe2", "vxp", "sort", "dflt", "vxp2", "nnpa", "sie"},
+			Frequency: 5200,
+			ModelName: "3931",
 		}
 		Expect(ret).To(Equal(&expected))
 	})


### PR DESCRIPTION
For s390x architectures lscpu does not return the clock speed by "CPU MHz" or "CPU max MHz" field but have two fields (CPU static MHz and CPU dynamic MHz). 
"CPU static MHz" is the field representing the designed clock speed whereas the "CPU dynamic MHz" is representing the current CPU speed (throttled or energy saving).
New test case for s390x architecture was added. 
In addition the machine type was fixed, too.

The fix was tested using unit tests:

JUnit path was configured: ./junit_unit_test.xml

JUnit report was created: /root/code/Assisted_Installer/latest/assisted-installer-agent/src/inventory/junit_unit_test.xml

Ran 121 of 121 Specs in 0.268 seconds
SUCCESS! -- 121 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestInventory (0.30s)
  