### PR TITLE
MGMT-19595: Push latest tag for downstream image after merge to konflux int repo

### DIFF
--- a/.tekton/assisted-installer-agent-downstream-main-push.yaml
+++ b/.tekton/assisted-installer-agent-downstream-main-push.yaml
@@ -530,6 +530,8 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value: ["latest"]
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Our integration environment uses latest tags, so we need the push-event pipelines to also push latest tag.

Part-of [MGMT-19595](https://issues.redhat.com//browse/MGMT-19595)