### PR TITLE
MGMT-19381: Change downstream base images to rhel9.4 instead of ubi9

### DIFF
--- a/Dockerfile.assisted_installer_agent-downstream
+++ b/Dockerfile.assisted_installer_agent-downstream
@@ -17,7 +17,7 @@ RUN go install github.com/google/go-licenses@v1.6.0
 RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
 
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+FROM --platform=$BUILDPLATFORM registry.redhat.io/rhel9-4-els/rhel:9.4
 ARG release=main
 ARG version=latest
 

--- a/Dockerfile.assisted_installer_agent-mce
+++ b/Dockerfile.assisted_installer_agent-mce
@@ -20,7 +20,7 @@ RUN ${HOME}/go/bin/go-licenses save --save_path /tmp/licenses ./...
 RUN CGO_FLAG=1 make build
 
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+FROM --platform=$BUILDPLATFORM registry.redhat.io/rhel9-4-els/rhel:9.4
 ARG release=main
 ARG version=latest
 


### PR DESCRIPTION
Currently our base images use ubi9 and MintMaker wants to upgrade it to 9.5, because MintMaker looks at the repo and tries to upgrade to the newest tag.
This changes the base image to use a repo that is just for rhel9.4.

Part-of [MGMT-19381](https://issues.redhat.com//browse/MGMT-19381)