### PR TITLE
MGMT-19815: Update tekton pipelines to point to new components

### DIFF
--- a/.tekton/assisted-installer-agent-acm-ds-2-13-pull-request.yaml
+++ b/.tekton/assisted-installer-agent-acm-ds-2-13-pull-request.yaml
@@ -4,16 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/assisted-installer-agent?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "release-ocm-2.13"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-agent-mce-downstream-2-13
-    appstudio.openshift.io/component: assisted-installer-agent-mce-downstream-2-13
+    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2-13
+    appstudio.openshift.io/component: assisted-installer-agent-acm-ds-2-13
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-agent-mce-downstream-2-13-on-push
+  name: assisted-installer-agent-acm-ds-2-13-on-pull-request
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -22,7 +23,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-agent-mce-downstream-2-13/assisted-installer-agent-mce-downstream-2-13:{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2-13/assisted-installer-agent-acm-ds-2-13:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/assisted-installer-agent-acm-ds-2-13-push.yaml
+++ b/.tekton/assisted-installer-agent-acm-ds-2-13-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "master"
+      == "release-ocm-2.13"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-agent-mce-downstream-main
-    appstudio.openshift.io/component: assisted-installer-agent-mce-downstream-main
+    appstudio.openshift.io/application: assisted-installer-application-acm-ds-2-13
+    appstudio.openshift.io/component: assisted-installer-agent-acm-ds-2-13
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-agent-mce-downstream-main-on-push
+  name: assisted-installer-agent-acm-ds-2-13-on-push
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-agent-mce-downstream-main/assisted-installer-agent-mce-downstream-main:{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-2-13/assisted-installer-agent-acm-ds-2-13:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/assisted-installer-agent-acm-ds-main-pull-request.yaml
+++ b/.tekton/assisted-installer-agent-acm-ds-main-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "release-ocm-2.13"
+      == "master"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-agent-mce-downstream-2-13
-    appstudio.openshift.io/component: assisted-installer-agent-mce-downstream-2-13
+    appstudio.openshift.io/application: assisted-installer-application-acm-ds-main
+    appstudio.openshift.io/component: assisted-installer-agent-acm-ds-main
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-agent-mce-downstream-2-13-on-pull-request
+  name: assisted-installer-agent-acm-ds-main-on-pull-request
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-agent-mce-downstream-2-13/assisted-installer-agent-mce-downstream-2-13:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-main/assisted-installer-agent-acm-ds-main:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/assisted-installer-agent-acm-ds-main-push.yaml
+++ b/.tekton/assisted-installer-agent-acm-ds-main-push.yaml
@@ -4,17 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/assisted-installer-agent?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-agent-mce-downstream-main
-    appstudio.openshift.io/component: assisted-installer-agent-mce-downstream-main
+    appstudio.openshift.io/application: assisted-installer-application-acm-ds-main
+    appstudio.openshift.io/component: assisted-installer-agent-acm-ds-main
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-agent-mce-downstream-main-on-pull-request
+  name: assisted-installer-agent-acm-ds-main-on-push
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -23,9 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-agent-mce-downstream-main/assisted-installer-agent-mce-downstream-main:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-acm-ds-main/assisted-installer-agent-acm-ds-main:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/assisted-installer-agent-ds-main-pull-request.yaml
+++ b/.tekton/assisted-installer-agent-ds-main-pull-request.yaml
@@ -11,10 +11,10 @@ metadata:
       == "master"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-agent-downstream-main
-    appstudio.openshift.io/component: assisted-installer-agent-downstream-main
+    appstudio.openshift.io/application: assisted-installer-application-ds-main
+    appstudio.openshift.io/component: assisted-installer-agent-ds-main
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-agent-downstream-main-on-pull-request
+  name: assisted-installer-agent-ds-main-on-pull-request
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-agent-downstream-main/assisted-installer-agent-downstream-main:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-ds-main/assisted-installer-agent-ds-main:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms

--- a/.tekton/assisted-installer-agent-ds-main-push.yaml
+++ b/.tekton/assisted-installer-agent-ds-main-push.yaml
@@ -10,10 +10,10 @@ metadata:
       == "master"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: assisted-installer-agent-downstream-main
-    appstudio.openshift.io/component: assisted-installer-agent-downstream-main
+    appstudio.openshift.io/application: assisted-installer-application-ds-main
+    appstudio.openshift.io/component: assisted-installer-agent-ds-main
     pipelines.appstudio.openshift.io/type: build
-  name: assisted-installer-agent-downstream-main-on-push
+  name: assisted-installer-agent-ds-main-on-push
   namespace: assisted-installer-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-agent-downstream-main/assisted-installer-agent-downstream-main:{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-installer-application-ds-main/assisted-installer-agent-ds-main:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
In order to simplify the release process in konflux for our product, we want related components to share a single application. To make that change as simple as possible, this PR changes the existing pipelines to point to the new components while keeping everything we already configured.

Part-of MGMT-19815