### PR TITLE
NO-ISSUE: Increase image pull timeout during install

### DIFF
--- a/src/commands/actions/install_cmd.go
+++ b/src/commands/actions/install_cmd.go
@@ -27,7 +27,7 @@ const (
 	templateGetImage          = "podman images --quiet %s"
 	failedToPullImageExitCode = 2
 	defaultImagePullRetries   = 3
-	defaultImagePullTimeout   = 30
+	defaultImagePullTimeout   = 600
 )
 
 var podmanBaseCmd = [...]string{
@@ -334,8 +334,8 @@ func pullImage(pullTimeoutSeconds int64, image string) error {
 	case 0:
 		return nil
 	case util.TimeoutExitCode:
-		return errors.Errorf("podman pull was timed out after %d seconds", pullTimeoutSeconds)
+		return errors.Errorf("pulling the installer image %s timed out after %d seconds", image, pullTimeoutSeconds)
 	default:
-		return errors.Errorf("podman pull exited with non-zero exit code %d: %s\n %s", exitCode, stdout, stderr)
+		return errors.Errorf("pulling the installer image %s exited with non-zero exit code %d: %s\n %s", image, exitCode, stdout, stderr)
 	}
 }


### PR DESCRIPTION
Previously, there was a timeout of 30 seconds when pulling the installer image. This is not enough
time to pull the image and to mark the installation as failed.

This change increases the timeout to 600 seconds
(10 minutes), which is more accurate for a failed
image pull. The error message from failing to pull has also been updated to reflect the actual failure.

/cc @omertuc 