### PR TITLE
[release-ocm-2.13] MGMT-19953: Reduce the OWNERS list for release-ocm-2.13 as it is feature complete

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,33 +2,11 @@
 
 aliases:
   approvers:
-    - avishayt
-    - eranco74
-    - gamli75
-    - ori-amizur
     - romfreiman
-    - tsorya
-    - carbonin
-    - danielerez
-    - omertuc
+    - oourfali
+    - gamli75
     - eliorerz
-    - paul-maidment
     - rccrdpccl
-    - jhernand
     - adriengentil
     - danmanor
     - eifrach
-    - linoyaslan
-    - giladravid16
-    - pastequo
-  emeritus_approvers:
-    - empovit
-    - yevgeny-shnaidman
-    - lranjbar
-    - ybettan
-  agent_team:
-    - andfasano
-    - bfournie
-    - pawanpinjarkar
-    - rwsu
-    - zaneb


### PR DESCRIPTION
The list was copied from `release-ocm-2.12`