### PR TITLE
MGMT-19588: Also use bond interface for hostname workaround

### DIFF
--- a/src/inventory/inventory_test.go
+++ b/src/inventory/inventory_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Hostname processing", func() {
 				{
 					Name:       "eth0",
 					Type:       "physical",
-					MacAddress: "71:A0:A4:6F:BE:C8",
+					MacAddress: "71:A0:A4:6F:BE:C7",
 				},
 				{
 					Name:          "eth0.42",
@@ -215,6 +215,24 @@ var _ = Describe("Hostname processing", func() {
 				},
 			},
 			"71-a0-a4-6f-be-c8",
+		),
+		Entry(
+			"Renames with bond",
+			"localhost.localdomain",
+			[]*models.Interface{
+				{
+					Name:       "eth0",
+					Type:       "physical",
+					MacAddress: "71:A0:A4:6F:BE:C8",
+				},
+				{
+					Name:          "bond0",
+					Type:          "bond",
+					MacAddress:    "52:54:00:aa:3d:c4",
+					IPV4Addresses: []string{"192.168.124.33/24"},
+				},
+			},
+			"52-54-00-aa-3d-c4",
 		),
 	)
 })


### PR DESCRIPTION
Tested with libvirt by creating a VM with 2 network interfaces. Then inside the VM, the bond was created manually with nmcli following [this](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking#configuring-a-network-bond-by-using-nmcli_configuring-network-bonding) 

I only tried the `active-backup` mode, not sure if it could have an impact