### PR TITLE
MGMT-19966: fix route protocol returns string instead of int

### DIFF
--- a/src/util/network.go
+++ b/src/util/network.go
@@ -107,7 +107,7 @@ func isUsableIPv6Route(route netlink.Route) bool {
 		return false
 	}
 	// Ignore non-advertised routes
-	if route.Protocol != unix.RTPROT_RA {
+	if int(route.Protocol) != unix.RTPROT_RA {
 		return false
 	}
 


### PR DESCRIPTION
- fix when compare the route protocol vs `unix.RTPROT_RA` it return a string value of the protocol.