### PR TITLE
MGMT-19420: --high-availability-mode was removed from CLI arguments.

### DIFF
--- a/src/commands/actions/install_cmd.go
+++ b/src/commands/actions/install_cmd.go
@@ -107,13 +107,6 @@ func (a *install) getFullInstallerCommand() string {
 
 	if a.installParams.ControlPlaneCount != 0 {
 		installerCmdArgs = append(installerCmdArgs, "--control-plane-count", strconv.Itoa(int(a.installParams.ControlPlaneCount)))
-	} else {
-		switch swag.StringValue(a.installParams.HighAvailabilityMode) {
-		case models.ClusterHighAvailabilityModeFull:
-			installerCmdArgs = append(installerCmdArgs, "--control-plane-count", "3")
-		case models.ClusterHighAvailabilityModeNone:
-			installerCmdArgs = append(installerCmdArgs, "--control-plane-count", "1")
-		}
 	}
 
 	if a.installParams.McoImage != "" {


### PR DESCRIPTION
[MGMT-19420](https://issues.redhat.com//browse/MGMT-19420): second phase, which means that --high-availability-mode was removed from CLI arguments.