### PR TITLE
MGMT-20227: Skip Motherboard serial if set to "-" (#955)

### DIFF
--- a/src/scanners/machine_uuid_scanner.go
+++ b/src/scanners/machine_uuid_scanner.go
@@ -32,7 +32,7 @@ var (
 	FailureUUID = strfmt.UUID("deaddead-dead-dead-dead-deaddeaddead")
 )
 
-var unknownSerialCases = []string{"", util.UNKNOWN, "none",
+var unknownSerialCases = []string{"", util.UNKNOWN, "none", "-",
 	SerialUnspecifiedBaseBoardString, SerialUnspecifiedSystemString,
 	SerialDefaultString, SerialNotSpecified, strings.ToLower(SerialProliantGen11)}
 var unknownUuidCases = []string{"", util.UNKNOWN, ZeroesUUID, KaloomUUID}

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -65,6 +65,17 @@ var _ = Describe("Machine uuid test", func() {
 		id := ReadId(serialDiscovery, dependencies)
 		Expect(id).To(Equal(toUUID(TestUuid)))
 	})
+	It("dash serial", func() {
+		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "-"}, nil).Once()
+		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
+		id := ReadId(serialDiscovery, dependencies)
+		Expect(id).To(Equal(toUUID(TestUuid)))
+	})
+	It("dash serial embedded", func() {
+		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "123-456-789"}, nil).Once()
+		id := ReadId(serialDiscovery, dependencies)
+		Expect(id).To(Equal(toUUID("856f4f9c-3c08-4d97-8ec7-ea0ad7d4cadf")))
+	})
 
 	tests := []struct {
 		useCase  string


### PR DESCRIPTION
Certain hardware sets the Motherboard serial number to "-" if not configured. This should be skipped to prevent all hosts generating the same UUID.