### PR TITLE
MGMT-20669: Fix hostname update for inventory get host

### DIFF
--- a/src/commands/actions/next_step_runner.go
+++ b/src/commands/actions/next_step_runner.go
@@ -53,7 +53,7 @@ func (a *nextStepRunnerAction) cleanupPrevious() {
 func (a *nextStepRunnerAction) Args() []string {
 	a.cleanupPrevious()
 
-	arguments := []string{"run", "--rm", "-ti", "--privileged", "--pid=host", "--net=host",
+	arguments := []string{"run", "--rm", "-ti", "--privileged", "--pid=host", "--uts=host", "--net=host",
 
 		// unlimited number of processes in the container
 		"--pids-limit=0",


### PR DESCRIPTION
When hostname changed from node, the inventory get host does not update the service. On hostname action , linux updates /proc/sys/kernel/hostname file on node but it does not update the kernel hostname on next_step_runner container.

Due to this issue manual hostname update or changes after starting next_step_runner never reflected unless we restart agent.

In order to fix it added to next_step_runner --uts=host flag. With this flag changes on /proc/sys/kernel/hostname reflected to the container path.