### PR TITLE
MGMT-18993: ensure the agent reports the permMacAddress of network interfaces

### DIFF
--- a/src/inventory/interfaces_test.go
+++ b/src/inventory/interfaces_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Interfaces", func() {
 		dependencies.On("ReadFile", "/sys/class/net/eth0/carrier").Return([]byte("1\n"), nil).Once()
 		dependencies.On("ReadFile", "/sys/class/net/eth0/device/device").Return([]byte("my-device"), nil).Once()
 		dependencies.On("ReadFile", "/sys/class/net/eth0/device/vendor").Return([]byte("my-vendor"), nil).Once()
-		dependencies.On("LinkByName", "eth0").Return(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}, nil).Once()
+		util.SetupNetlinkMocks(dependencies, []util.Interface{interfaceMock})
 		dependencies.On("RouteList", mock.Anything, mock.Anything).Return([]netlink.Route{
 			{
 				Dst:      &net.IPNet{IP: net.ParseIP("de90::"), Mask: net.CIDRMask(64, 128)},
@@ -105,7 +105,7 @@ var _ = Describe("Interfaces", func() {
 		dependencies.On("ReadFile", "/sys/class/net/eth2.10/carrier").Return(nil, errors.New("Blah")).Once()
 		dependencies.On("ReadFile", "/sys/class/net/eth2.10/device/device").Return(nil, errors.New("Blah")).Once()
 		dependencies.On("ReadFile", "/sys/class/net/eth2.10/device/vendor").Return([]byte("my-vendor2"), nil).Once()
-		dependencies.On("LinkByName", mock.Anything).Return(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}, nil)
+		util.SetupNetlinkMocks(dependencies, rets)
 		dependencies.On("RouteList", mock.Anything, mock.Anything).Return([]netlink.Route{
 			{
 				Dst:      &net.IPNet{IP: net.ParseIP("de90::"), Mask: net.CIDRMask(62, 128)},

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Machine uuid test", func() {
 			dependencies.On("ReadFile", "/sys/class/net/eth1/carrier").Return(nil, errors.New("Blah")).Once()
 			dependencies.On("ReadFile", "/sys/class/net/eth1/device/device").Return(nil, errors.New("Blah")).Once()
 			dependencies.On("ReadFile", "/sys/class/net/eth1/device/vendor").Return([]byte("my-vendor2"), nil).Once()
-			dependencies.On("LinkByName", mock.Anything).Return(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}, nil)
+			agentutils.SetupNetlinkMocks(dependencies, rets)
 			dependencies.On("RouteList", mock.Anything, mock.Anything).Return([]netlink.Route{
 				{
 					Dst:      &net.IPNet{IP: net.ParseIP("de90::"), Mask: net.CIDRMask(64, 128)},


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-18993
When installing a node configured with a bond interface comprising of two or more network interfaces, the mac address of the bond and all its slave interfaces is set to match the mac address of the first slave. This can lead to a mismatch with the bootMACAddress field of the corresponding BareMetalHost, preventing the agent from being correctly matched with it.
This PR ensures that each interface retains its actual permanent mac address, rather than the visible address set by the bonding configuration.