### PR TITLE
MGMT-20868: trust also system certs

### DIFF
--- a/src/session/inventory_session.go
+++ b/src/session/inventory_session.go
@@ -204,7 +204,11 @@ func readCACertificate(agentConfig *config.AgentConfig) (*x509.CertPool, error) 
 		return nil, err
 	}
 
-	pool := x509.NewCertPool()
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system cert pool: %w", err)
+	}
+
 	if !pool.AppendCertsFromPEM(caData) {
 		return nil, fmt.Errorf("failed to load certificate: %s", agentConfig.CACertificatePath)
 	}


### PR DESCRIPTION
# Background

When the agent reaches out to the service, it uses the --cacert parameter passed to it and uses only the certificates in that file.

On SaaS, this parameter is usually not passed and the agent uses the system certs, which work because our SaaS is signed by a public CA.

On Kube-API, the agent is configured with a CA certificate that corresponds to the cluster's ingress. This is because the agent reaches the service through the cluster's ingress load balancer.

Some users like configuring a different CA certificate for their cluster's ingress. Ideally we should identify that automatically and pass those certs to the agent as `--cacert`, but until then users can simply use our `AdditionalTrustBundle` parameter and add their certs to make it work.

# Issue

The `--cacert` parameter still contains the cluster's default ingress certs, and since the agent uses ONLY those certs, it fails to connect to the service (behind the user's custom ingress).

# Solution

This commit changes the agent to use the system cert pool in addition to the `--cacert` parameter. This way the certs defined in `AdditionalTrustBundle`, which reach the system cert pool, will be used by the agent.

# Implementation details

Use `SystemCertPool` instead of `NewCertPool`. The former loads the system certs, the latter starts with an empty cert pool.