### PR TITLE
OCPBUGS-59297: Bump glog to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-	github.com/golang/glog v1.2.0 // indirect
+	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.0 h1:uCdmnmatrKCgMBlM4rMuJZWOkPDqdbZPnrMXDY4gI68=
-github.com/golang/glog v1.2.0/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
+github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/vendor/github.com/golang/glog/glog.go
+++ b/vendor/github.com/golang/glog/glog.go
@@ -76,7 +76,7 @@
 //			-log_backtrace_at=gopherflakes.go:234
 //		A stack trace will be written to the Info log whenever execution
 //		hits one of these statements. (Unlike with -vmodule, the ".go"
-//		must bepresent.)
+//		must be present.)
 //	-v=0
 //		Enable V-leveled logging at the specified level.
 //	-vmodule=""
@@ -238,6 +238,8 @@ func ctxlogf(ctx context.Context, depth int, severity logsink.Severity, verbose 
 	metaPool.Put(metai)
 }
 
+var sinkErrOnce sync.Once
+
 func sinkf(meta *logsink.Meta, format string, args ...any) {
 	meta.Depth++
 	n, err := logsink.Printf(meta, format, args...)
@@ -247,9 +249,20 @@ func sinkf(meta *logsink.Meta, format string, args ...any) {
 	}
 
 	if err != nil {
-		logsink.Printf(meta, "glog: exiting because of error: %s", err)
-		sinks.file.Flush()
-		os.Exit(2)
+		// Best-effort to generate a reasonable Fatalf-like
+		// error message in all sinks that are still here for
+		// the first goroutine that comes here and terminate
+		// the process.
+		sinkErrOnce.Do(func() {
+			m := &logsink.Meta{}
+			m.Time = timeNow()
+			m.Severity = logsink.Fatal
+			m.Thread = int64(pid)
+			_, m.File, m.Line, _ = runtime.Caller(0)
+			format, args := appendBacktrace(1, "log: exiting because of error writing previous log to sinks: %v", []any{err})
+			logsink.Printf(m, format, args...)
+			flushAndAbort()
+		})
 	}
 }
 
@@ -642,6 +655,10 @@ func ErrorContextDepthf(ctx context.Context, depth int, format string, args ...a
 
 func ctxfatalf(ctx context.Context, depth int, format string, args ...any) {
 	ctxlogf(ctx, depth+1, logsink.Fatal, false, withStack, format, args...)
+	flushAndAbort()
+}
+
+func flushAndAbort() {
 	sinks.file.Flush()
 
 	err := abortProcess() // Should not return.

--- a/vendor/github.com/golang/glog/glog_file_nonwindows.go
+++ b/vendor/github.com/golang/glog/glog_file_nonwindows.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package glog
+
+import "os/user"
+
+// shouldRegisterStderrSink determines whether we should register a log sink that writes to stderr.
+// Today, this always returns true on non-Windows platforms, as it specifically checks for a
+// condition that is only present on Windows.
+func shouldRegisterStderrSink() bool {
+	return true
+}
+
+func lookupUser() string {
+	if current, err := user.Current(); err == nil {
+		return current.Username
+	}
+	return ""
+}

--- a/vendor/github.com/golang/glog/glog_file_windows.go
+++ b/vendor/github.com/golang/glog/glog_file_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package glog
+
+import (
+	"os"
+	"syscall"
+)
+
+// shouldRegisterStderrSink determines whether we should register a log sink that writes to stderr.
+// Today, this checks if stderr is "valid", in that it maps to a non-NULL Handle.
+// Windows Services are spawned without Stdout and Stderr, so any attempt to use them equates to
+// referencing an invalid file Handle.
+// os.Stderr's FD is derived from a call to `syscall.GetStdHandle(syscall.STD_ERROR_HANDLE)`.
+// Documentation[1] for the GetStdHandle function indicates the return value may be NULL if the
+// application lacks the standard handle, so consider Stderr valid if its FD is non-NULL.
+// [1]: https://learn.microsoft.com/en-us/windows/console/getstdhandle
+func shouldRegisterStderrSink() bool {
+	return os.Stderr.Fd() != 0
+}
+
+// This follows the logic in the standard library's user.Current() function, except
+// that it leaves out the potentially expensive calls required to look up the user's
+// display name in Active Directory.
+func lookupUser() string {
+	token, err := syscall.OpenCurrentProcessToken()
+	if err != nil {
+		return ""
+	}
+	defer token.Close()
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return ""
+	}
+	username, _, accountType, err := tokenUser.User.Sid.LookupAccount("")
+	if err != nil {
+		return ""
+	}
+	if accountType != syscall.SidTypeUser {
+		return ""
+	}
+	return username
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -223,7 +223,7 @@ github.com/gogo/protobuf/sortkeys
 # github.com/golang-jwt/jwt/v4 v4.5.2
 ## explicit; go 1.16
 github.com/golang-jwt/jwt/v4
-# github.com/golang/glog v1.2.0
+# github.com/golang/glog v1.2.5
 ## explicit; go 1.19
 github.com/golang/glog
 github.com/golang/glog/internal/logsink


### PR DESCRIPTION
updating glog to 1.2.5 fixes the CVE https://pkg.go.dev/vuln/GO-2025-3372