### PR TITLE
KONFLUX-6210: fix and set name and cpe label for assisted-installer-agent-ds-main

### DIFF
--- a/Dockerfile.assisted_installer_agent-downstream
+++ b/Dockerfile.assisted_installer_agent-downstream
@@ -40,7 +40,8 @@ RUN INSTALL_PKGS="findutils iputils podman ipmitool file sg3_utils fio nmap dhcl
     rm -rf /var/cache/{yum,dnf}/*
 
 LABEL com.redhat.component="assisted-installer-agent-container" \
-      name="assisted-installer-agent" \
+      name="rhai/assisted-installer-agent-rhel9" \
+      cpe="cpe:/a:redhat:assisted_installer:2.38::el9" \
       version="${version}" \
       upstream-ref="${version}" \
       upstream-url="https://github.com/openshift/assisted-installer-agent.git" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
