### PR TITLE
[release-ocm-2.12] - ACM-24320: CVE-2025-47907 Upgrade golang to 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,58 +15,58 @@ run:
   # include test files or not, default is true
   tests: true
 
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  skip-dirs:
-    - build 
-    - client 
-    - docs
-    - models
-    - restapi
-
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
   # print lines of code with issue, default is true
   print-issued-lines: true
 
   # print linter name in the end of issue text, default is true
   print-linter-name: true
 
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
 issues:
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  exclude-dirs:
+    - build 
+    - client 
+    - docs
+    - models
+    - restapi
+
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,
   # it can be disabled by `exclude-use-default: false`. To list all
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - G107
+    - G115  # Integer overflow conversion
     - G402  # support scality DisableSSL
     - G401  # Use of weak cryptographic primitive
     - G501  # Blacklisted import `crypto/md5`: weak cryptographic primitive
     - '"ok" shadows declaration'
 
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
 linters:
   enable:
-    - megacheck
+    - gosimple
+    - staticcheck
+    - unused
     - govet
     - gocyclo
     - gofmt
     - gosec
-    - megacheck
     - unconvert
     - goimports
-    - exportloopref
+    - copyloopvar
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
 
     settings:
       printf:

--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETPLATFORM
 ENV GO111MODULE=on
 ENV GOFLAGS=""

--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS golang
 
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.56.0 && \
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8 && \
         go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
         go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
         go install github.com/golang/mock/mockgen@v1.6.0 && \

--- a/Dockerfile.assisted_installer_agent-mce
+++ b/Dockerfile.assisted_installer_agent-mce
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETPLATFORM
 
 ENV USER_UID=1001 \

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,5 @@
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer-agent
 COPY . . 

--- a/src/logs_sender/send_logs.go
+++ b/src/logs_sender/send_logs.go
@@ -339,8 +339,9 @@ func uploadLogs(l LogsSender, inputPath string, archivePath string) error {
 	_, errOut, execCode := l.Execute("tar", args...)
 
 	if execCode != 0 {
-		log.WithError(errors.Errorf(errOut)).Errorf("Failed to run to archive %s.", inputPath)
-		return fmt.Errorf(errOut)
+		err := errors.Errorf(errOut)
+		log.WithError(err).Errorf("Failed to run to archive %s.", inputPath)
+		return err
 	}
 
 	err := l.FileUploader(archivePath)


### PR DESCRIPTION
## Jira Tickets
- https://issues.redhat.com/browse/ACM-24320

##
Update go version to 1.24 to address cve CVE-2025-47907