### PR TITLE
[release-ocm-2.8] - CVE-2025-47907: Upgrade golang to 1.24.6

### DIFF
--- a/Dockerfile.assisted_installer_agent
+++ b/Dockerfile.assisted_installer_agent
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.19 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS builder
 
 USER 0
 

--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.19 AS golang
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6 AS golang
 
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.56.0 && \
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8 && \
         go install golang.org/x/tools/cmd/goimports@v0.1.0 && \
         go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
         go install github.com/golang/mock/mockgen@v1.6.0 && \


### PR DESCRIPTION
Security fix for CVE-2025-47907:
Upgrading golang to 1.24.6