### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for assisted-installer-agent-acm-ds-2-14

### DIFF
--- a/Dockerfile.assisted_installer_agent-mce
+++ b/Dockerfile.assisted_installer_agent-mce
@@ -53,6 +53,7 @@ LABEL com.redhat.component="multicluster-engine-assisted-installer-agent-contain
       io.k8s.description="OpenShift Assisted Installer" \
       distribution-scope="public" \
       release="${release}" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       vendor="Red Hat, Inc." \
       io.openshift.tags="OpenShift 4" \
       upstream_commit="${version}" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
