### PR TITLE
OCPBUGS-62390: Bump dockerfile images to 4.21

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,11 +1,11 @@
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer-agent
 COPY . . 
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 
 LABEL io.openshift.release.operator=true
 


### PR DESCRIPTION
Rebased version of #1138 