### PR TITLE
MGMT-21724: Update Renovate for legacy EL8 Dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,17 @@
             ],
             "depNameTemplate": "registry.access.redhat.com/ubi9/go-toolset",
             "datasourceTemplate": "docker"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^Dockerfile.assisted_installer_agent-mce$"
+            ],
+            "matchStrings": [
+                "FROM --platform=\\$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:(?<currentValue>.*?) AS builder\\n"
+            ],
+            "depNameTemplate": "registry.access.redhat.com/ubi8/go-toolset",
+            "datasourceTemplate": "docker"
         }
     ],
 
@@ -51,13 +62,19 @@
             "groupName": "Go Builder",
             "addLabels": ["golang"],
             "matchDatasources": ["docker"],
-            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "matchPackageNames": [
+                "registry.access.redhat.com/ubi8/go-toolset",
+                "registry.access.redhat.com/ubi9/go-toolset"
+            ],
             "allowedVersions": "/^[0-9]+\\.[0-9]+$/"
         },
         {
             "matchUpdateTypes": ["major"],
             "matchDatasources": ["docker"],
-            "matchPackageNames": ["registry.access.redhat.com/ubi9/go-toolset"],
+            "matchPackageNames": [
+                "registry.access.redhat.com/ubi8/go-toolset",
+                "registry.access.redhat.com/ubi9/go-toolset"
+            ],
             "enabled": false
         },
         {


### PR DESCRIPTION
Adds a custom regex manager targeting registry.access.redhat.com/ubi8/go-toolset in Dockerfile.assisted_installer_agent-mce so that the release-ocm-2.11 branch also receives automatic go-toolset bumps.