### PR TITLE
[release-ocm-2.12] ACM-32553: CVE-2026-34986 Bump github.com/go-jose/go-jose/v3 to v3.0.5 using replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -207,3 +207,5 @@ replace (
 	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20201022175424-d30c7a274820
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20201016155852-4090a6970205
 )
+
+replace github.com/go-jose/go-jose/v3 => github.com/go-jose/go-jose/v3 v3.0.5

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1139,3 +1139,4 @@ sigs.k8s.io/yaml/goyaml.v2
 # golang.org/x/crypto => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
 # sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20201022175424-d30c7a274820
 # sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20201016155852-4090a6970205
+# github.com/go-jose/go-jose/v3 => github.com/go-jose/go-jose/v3 v3.0.5


### PR DESCRIPTION
Bump `github.com/go-jose/go-jose/v3` to `v3.0.5` to fix `CVE-2026-34986` using a replace directive

## Strategy Selection

### Strategies Not Applicable

- **Direct dependency version bump**
  Not applicable: dependency is indirect. Direct version bumps only work for explicitly required modules.

- **Direct dependency major version upgrade**
  Not applicable: dependency is indirect. Major version upgrades only apply to direct dependencies.

- **Indirect dependency fix via parent update**
  No suitable versions found for introducer(s): github.com/containerd/containerd

- **Indirect to direct dependency conversion**
  Attempted to pin github.com/go-jose/go-jose/v3 to a fixed version, but Go reverted it to indirect at v3.0.4. No other module requires this version directly, so the explicit requirement was automatically removed by Go's module resolution.

### ✓ Successful Strategy: Replace directive workaround
Added replace directive to override module resolution. Used as last resort when standard updates fail.

http://issues.redhat.com/browse/ACM-32553