### PR TITLE
MGMT-24376: Report InfiniBand NIC speed from HCA sysfs path

### DIFF
--- a/src/util/network_interface.go
+++ b/src/util/network_interface.go
@@ -84,6 +84,61 @@ func (n *NetworkInterface) IsVlan() bool {
 	return link.Type() == "vlan"
 }
 
+func (n *NetworkInterface) isInfiniBand() bool {
+	link, err := n.dependencies.LinkByName(n.netInterface.Name)
+	if err != nil {
+		logrus.WithError(err).Warnf("Could not get link for %s to check InfiniBand encap type", n.netInterface.Name)
+		return false
+	}
+	encapType := link.Attrs().EncapType
+	logrus.Debugf("Interface %s has encap type %q", n.netInterface.Name, encapType)
+	return encapType == "infiniband"
+}
+
+func (n *NetworkInterface) infinibandSpeedMbps() int64 {
+	ibDir := fmt.Sprintf("/sys/class/net/%s/device/infiniband", n.Name())
+	entries, err := n.dependencies.ReadDir(ibDir)
+	if err != nil || len(entries) == 0 {
+		logrus.WithError(err).Warnf("Could not find InfiniBand HCA for %s", n.Name())
+		return -1
+	}
+	hca := entries[0].Name()
+
+	portBytes, err := n.dependencies.ReadFile(fmt.Sprintf("/sys/class/net/%s/dev_port", n.Name()))
+	port := 1
+	if err != nil {
+		logrus.WithError(err).Debugf("Could not read dev_port for %s, defaulting to port 1", n.Name())
+	} else if parsed, parseErr := strconv.Atoi(strings.TrimSpace(string(portBytes))); parseErr != nil {
+		logrus.WithError(parseErr).Debugf("Could not parse dev_port for %s: %q, defaulting to port 1", n.Name(), strings.TrimSpace(string(portBytes)))
+	} else {
+		port = parsed + 1
+	}
+
+	rateFile := fmt.Sprintf("/sys/class/infiniband/%s/ports/%d/rate", hca, port)
+	rateBytes, err := n.dependencies.ReadFile(rateFile)
+	if err != nil {
+		logrus.WithError(err).Warnf("Could not read InfiniBand rate for %s", n.Name())
+		return -1
+	}
+
+	rateStr := strings.TrimSpace(string(rateBytes))
+	parts := strings.Fields(rateStr)
+	if len(parts) < 2 {
+		logrus.Warnf("Unexpected InfiniBand rate format for %s: %q", n.Name(), rateStr)
+		return -1
+	}
+
+	speed, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		logrus.WithError(err).Warnf("Could not parse InfiniBand rate for %s: %q", n.Name(), rateStr)
+		return -1
+	}
+
+	speedMbps := int64(speed * 1000)
+	logrus.Infof("InfiniBand interface %s: HCA=%s port=%d rate=%q speedMbps=%d", n.Name(), hca, port, rateStr, speedMbps)
+	return speedMbps
+}
+
 func (n *NetworkInterface) SpeedMbps() int64 {
 	b, err := n.dependencies.ReadFile(fmt.Sprintf("/sys/class/net/%s/speed", n.Name()))
 	if err != nil {
@@ -93,6 +148,10 @@ func (n *NetworkInterface) SpeedMbps() int64 {
 	ret, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 32)
 	if err != nil {
 		logrus.WithError(err).Warnf("Could not parse %s speed", n.Name())
+	}
+	// InfiniBand NICs report -1 via standard sysfs; try the InfiniBand-specific path
+	if ret <= 0 && n.isInfiniBand() {
+		return n.infinibandSpeedMbps()
 	}
 	return ret
 }

--- a/src/util/network_interface_test.go
+++ b/src/util/network_interface_test.go
@@ -1,0 +1,160 @@
+package util
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+)
+
+type fakeFileInfo struct {
+	name string
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() fs.FileMode  { return 0 }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return true }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+var _ = Describe("InfiniBand speed detection", func() {
+	var (
+		deps *MockIDependencies
+		ni   *NetworkInterface
+	)
+
+	BeforeEach(func() {
+		deps = &MockIDependencies{}
+		deps.On("GetGhwChrootRoot").Return("/host").Maybe()
+		ni = &NetworkInterface{
+			netInterface: net.Interface{Name: "ib0"},
+			dependencies: deps,
+		}
+	})
+
+	AfterEach(func() {
+		deps.AssertExpectations(GinkgoT())
+	})
+
+	It("falls back to InfiniBand sysfs when speed is -1", func() {
+		deps.On("ReadFile", "/sys/class/net/ib0/speed").Return([]byte("-1\n"), nil)
+		deps.On("LinkByName", "ib0").Return(&netlink.IPoIB{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:      "ib0",
+				EncapType: "infiniband",
+			},
+		}, nil)
+		deps.On("ReadDir", "/sys/class/net/ib0/device/infiniband").Return(
+			[]fs.FileInfo{fakeFileInfo{name: "mlx5_0"}}, nil,
+		)
+		deps.On("ReadFile", "/sys/class/net/ib0/dev_port").Return([]byte("0\n"), nil)
+		deps.On("ReadFile", "/sys/class/infiniband/mlx5_0/ports/1/rate").Return([]byte("400 Gb/sec (4X NDR)\n"), nil)
+
+		Expect(ni.SpeedMbps()).To(Equal(int64(400000)))
+	})
+
+	It("uses correct port number from dev_port", func() {
+		deps.On("ReadFile", "/sys/class/net/ib0/speed").Return([]byte("-1\n"), nil)
+		deps.On("LinkByName", "ib0").Return(&netlink.IPoIB{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:      "ib0",
+				EncapType: "infiniband",
+			},
+		}, nil)
+		deps.On("ReadDir", "/sys/class/net/ib0/device/infiniband").Return(
+			[]fs.FileInfo{fakeFileInfo{name: "mlx5_0"}}, nil,
+		)
+		deps.On("ReadFile", "/sys/class/net/ib0/dev_port").Return([]byte("1\n"), nil)
+		deps.On("ReadFile", "/sys/class/infiniband/mlx5_0/ports/2/rate").Return([]byte("200 Gb/sec (4X NDR)\n"), nil)
+
+		Expect(ni.SpeedMbps()).To(Equal(int64(200000)))
+	})
+
+	It("defaults to port 1 when dev_port is unreadable", func() {
+		deps.On("ReadFile", "/sys/class/net/ib0/speed").Return([]byte("-1\n"), nil)
+		deps.On("LinkByName", "ib0").Return(&netlink.IPoIB{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:      "ib0",
+				EncapType: "infiniband",
+			},
+		}, nil)
+		deps.On("ReadDir", "/sys/class/net/ib0/device/infiniband").Return(
+			[]fs.FileInfo{fakeFileInfo{name: "mlx5_0"}}, nil,
+		)
+		deps.On("ReadFile", "/sys/class/net/ib0/dev_port").Return(nil, errors.New("no such file"))
+		deps.On("ReadFile", "/sys/class/infiniband/mlx5_0/ports/1/rate").Return([]byte("400 Gb/sec (4X NDR)\n"), nil)
+
+		Expect(ni.SpeedMbps()).To(Equal(int64(400000)))
+	})
+
+	It("does not fall back for non-InfiniBand interfaces", func() {
+		ni.netInterface.Name = "bond0"
+		deps.On("ReadFile", "/sys/class/net/bond0/speed").Return([]byte("-1\n"), nil)
+		deps.On("LinkByName", "bond0").Return(&netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:      "bond0",
+				EncapType: "ether",
+			},
+		}, nil)
+
+		Expect(ni.SpeedMbps()).To(Equal(int64(-1)))
+	})
+
+	It("returns -1 when InfiniBand HCA directory is missing", func() {
+		deps.On("ReadFile", "/sys/class/net/ib0/speed").Return([]byte("-1\n"), nil)
+		deps.On("LinkByName", "ib0").Return(&netlink.IPoIB{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:      "ib0",
+				EncapType: "infiniband",
+			},
+		}, nil)
+		deps.On("ReadDir", "/sys/class/net/ib0/device/infiniband").Return(nil, errors.New("no such directory"))
+
+		Expect(ni.SpeedMbps()).To(Equal(int64(-1)))
+	})
+
+	It("returns -1 when rate file is unreadable", func() {
+		deps.On("ReadFile", "/sys/class/net/ib0/speed").Return([]byte("-1\n"), nil)
+		deps.On("LinkByName", "ib0").Return(&netlink.IPoIB{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:      "ib0",
+				EncapType: "infiniband",
+			},
+		}, nil)
+		deps.On("ReadDir", "/sys/class/net/ib0/device/infiniband").Return(
+			[]fs.FileInfo{fakeFileInfo{name: "mlx5_0"}}, nil,
+		)
+		deps.On("ReadFile", "/sys/class/net/ib0/dev_port").Return([]byte("0\n"), nil)
+		deps.On("ReadFile", "/sys/class/infiniband/mlx5_0/ports/1/rate").Return(nil, errors.New("permission denied"))
+
+		Expect(ni.SpeedMbps()).To(Equal(int64(-1)))
+	})
+
+	It("returns -1 when rate format is unexpected", func() {
+		deps.On("ReadFile", "/sys/class/net/ib0/speed").Return([]byte("-1\n"), nil)
+		deps.On("LinkByName", "ib0").Return(&netlink.IPoIB{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:      "ib0",
+				EncapType: "infiniband",
+			},
+		}, nil)
+		deps.On("ReadDir", "/sys/class/net/ib0/device/infiniband").Return(
+			[]fs.FileInfo{fakeFileInfo{name: "mlx5_0"}}, nil,
+		)
+		deps.On("ReadFile", "/sys/class/net/ib0/dev_port").Return([]byte("0\n"), nil)
+		deps.On("ReadFile", "/sys/class/infiniband/mlx5_0/ports/1/rate").Return([]byte("unknown\n"), nil)
+
+		Expect(ni.SpeedMbps()).To(Equal(int64(-1)))
+	})
+
+	It("does not attempt fallback for positive speed", func() {
+		deps.On("ReadFile", "/sys/class/net/ib0/speed").Return([]byte("1000\n"), nil)
+
+		Expect(ni.SpeedMbps()).To(Equal(int64(1000)))
+	})
+})


### PR DESCRIPTION
Add support for reporting InfiniBand NIC speed.

The IPoIB kernel driver sets dev->type = ARPHRD_INFINIBAND on the net_device ([source](https://github.com/torvalds/linux/blob/master/drivers/infiniband/ulp/ipoib/ipoib_main.c)), which the vishvananda/netlink library exposes as link.Attrs().EncapType == "infiniband" via its EncapType() mapping ([source](https://github.com/vishvananda/netlink/blob/main/nl/nl_linux.go)). For speed, the standard /sys/class/net/<iface>/speed returns -1 because the IPoIB driver doesn't implement the ethtool speed callback, so we fall back to /sys/class/infiniband/<hca>/ports/<port>/rate, which is populated by rate_show() ([source](https://github.com/torvalds/linux/blob/master/drivers/infiniband/core/sysfs.c)) in the InfiniBand core. The port number is derived from dev_port + 1 since the IPoIB driver stores priv->port - 1 into dev_port ([source](https://github.com/torvalds/linux/blob/master/drivers/infiniband/ulp/ipoib/ipoib_main.c)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and report InfiniBand NIC speeds using InfiniBand-specific sysfs data when standard speed reporting is unavailable.

* **Tests**
  * Added comprehensive tests covering InfiniBand detection, port selection/defaulting, speed derivation, fallback behavior, and error-handling cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->