### PR TITLE
MGMT-24453: upgrade to golang 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.21
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,11 @@ linters:
       - text: '"ok" shadows declaration'
         linters:
           - govet
+      # Test mock uses client.Do with test-only URLs — not a real SSRF risk
+      - text: "G704"
+        linters:
+          - gosec
+        path: _test\.go
     paths:
       - build
       - client

--- a/Dockerfile.assisted_installer_agent-build
+++ b/Dockerfile.assisted_installer_agent-build
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS golang
 
 ENV GOFLAGS=""
 
-RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2 && \
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.4 && \
         go install golang.org/x/tools/cmd/goimports@v0.34.0 && \
         go install github.com/onsi/ginkgo/ginkgo@v1.16.1 && \
         go install github.com/golang/mock/mockgen@v1.6.0 && \

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,5 @@
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 
 WORKDIR /go/src/github.com/openshift/assisted-installer-agent
 COPY . . 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/assisted-installer-agent
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.2
 
 require (
 	github.com/PuerkitoBio/rehttp v1.4.0


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.25 to 1.26 in go.mod and Dockerfiles
- Update toolchain to go1.26.2
- Bump golangci-lint from v2.12.2 to v2.11.4

https://redhat.atlassian.net/browse/MGMT-24453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain from version 1.25 to 1.26 across build and CI configuration.
  * Updated container build/root images to newer platform releases for the build pipeline.
  * Upgraded the linting tool version used during builds.
* **Quality**
  * Adjusted linting rules to exclude the GoSec G704 finding specifically in `_test.go` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->