### PR TITLE
MGMT-22787: Log inventory when it's too big

### DIFF
--- a/src/inventory/output.go
+++ b/src/inventory/output.go
@@ -50,6 +50,8 @@ func CreateInventoryOutput(inventoryConfig config.InventoryConfig, in *models.In
 
 	logrus.Warnf("Inventory size is still too large (%d bytes), it will be fully truncated", len(ret))
 
+	logrus.WithField("truncated_inventory", string(ret)).Info("Dumping partial inventory")
+
 	empty := &models.Inventory{
 		Truncation: &models.InventoryTruncation{
 			Type: models.InventoryTruncationTypeFull,


### PR DESCRIPTION
At first I was going to `Debug`, but `Info` might be more appropriate : we need something to investigate. I'm happy to change that if someone would prefer `Debug`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced system diagnostics by improving logging when inventory data exceeds maximum size limits. The system now captures and records detailed diagnostic information about partial payloads before truncation, providing better visibility for troubleshooting large inventory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->