### PR TITLE
MGMT-20398: Don't start main agent until ironic reports it's ready

### DIFF
--- a/src/agent/main/main.go
+++ b/src/agent/main/main.go
@@ -53,6 +53,14 @@ func getMapKeysSorted(binaries map[string]func()) []string {
 func Main() {
 	agentConfig := config.ProcessArgs()
 	util.SetLogging("agent_registration", agentConfig.TextLogging, agentConfig.JournalLogging, agentConfig.StdoutLogging, agentConfig.ForcedHostID)
+
+	logger := logrus.StandardLogger()
+
+	// Check ironic agent readiness status before proceeding
+	if err := util.ValidateStatusFile(agentConfig.IronicStatusFilePath); err != nil {
+		logger.WithError(err).Fatal("Failed to validate ironic status file")
+	}
+
 	nextStepRunnerFactory := agent.NewNextStepRunnerFactory()
-	agent.RunAgent(agentConfig, nextStepRunnerFactory, logrus.StandardLogger())
+	agent.RunAgent(agentConfig, nextStepRunnerFactory, logger)
 }

--- a/src/config/agent_config.go
+++ b/src/config/agent_config.go
@@ -10,8 +10,9 @@ import (
 type AgentConfig struct {
 	DryRunConfig
 	ConnectivityConfig
-	IntervalSecs int
-	HostID       string
+	IntervalSecs         int
+	HostID               string
+	IronicStatusFilePath string
 	LoggingConfig
 }
 
@@ -37,8 +38,18 @@ func ProcessArgs() *AgentConfig {
 	flag.StringVar(&ret.CACertificatePath, "cacert", "", "Path to custom CA certificate in PEM format")
 	flag.BoolVar(&ret.InsecureConnection, "insecure", false, "Do not validate TLS certificate")
 	flag.StringVar(&ret.HostID, "host-id", "", "Host identification")
+	flag.StringVar(&ret.IronicStatusFilePath, "ironic-status-file", "", "Path to ironic agent status file for readiness check")
 	h := flag.Bool("help", false, "Help message")
 	flag.Parse()
+
+	// Set ironic status file path from CLI flag or environment variable
+	if ret.IronicStatusFilePath == "" {
+		ret.IronicStatusFilePath = os.Getenv("IRONIC_STATUS_FILE")
+	}
+	// If neither flag nor env var is set, use the default path
+	if ret.IronicStatusFilePath == "" {
+		ret.IronicStatusFilePath = "/run/ironic/status.json"
+	}
 	if h != nil && *h {
 		printHelpAndExit()
 	}

--- a/src/util/status_file.go
+++ b/src/util/status_file.go
@@ -1,0 +1,123 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// StatusFileContent represents the structure of the ironic agent status file
+type StatusFileContent struct {
+	Status string `json:"status"`
+}
+
+const (
+	StatusInitializing    = "initializing"
+	StatusWaitingForAgent = "waiting for assisted agent"
+	StatusFinalizing      = "finalizing"
+)
+
+var (
+	waitingLoop = 2 * time.Second
+)
+
+// ValidateStatusFile checks the ironic agent status file and waits for readiness if needed.
+// It implements the following state machine:
+// - File not found: Feature not implemented (skip wait)
+// - Empty file: Feature available but initializing (wait indefinitely)
+// - {"status": "initializing"}: Ironic agent starting up (wait indefinitely)
+// - {"status": ""}: Transitional state (wait indefinitely)
+// - {"status": "waiting for assisted agent"}: Safe to proceed (proceed immediately)
+// - {"status": "finalizing"}: Ironic agent already finished (error - exit)
+// - Any other content: Unexpected state (error - exit)
+func ValidateStatusFile(filePath string) error {
+	logger := logrus.StandardLogger()
+
+	// Should not happen
+	if filePath == "" {
+		logger.Info("No ironic status file path configured, skipping readiness check")
+
+		return nil
+	}
+
+	// Check if file exists
+	_, err := os.Stat(filePath)
+	if err != nil {
+		switch {
+		case os.IsNotExist(err):
+			logger.Info("Ironic status file not found, feature not implemented - proceeding immediately")
+
+			return nil
+
+		default:
+			return fmt.Errorf("failed to check ironic status file (%s): %w", filePath, err)
+		}
+	}
+
+	// File exists, read and validate its content
+	logger.Info("Ironic status file found, checking readiness status")
+
+	err = waitForIronicReadiness(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to check ironic readiness: %w", err)
+	}
+
+	return nil
+}
+
+func waitForIronicReadiness(filePath string) error {
+	logger := logrus.StandardLogger()
+
+	for {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+
+		// Handle empty file - feature is available but still initializing
+		if len(content) == 0 {
+			logger.Debug("Ironic status file is empty, ironic agent still initializing - waiting")
+			time.Sleep(waitingLoop)
+
+			continue
+		}
+
+		// Parse the JSON content
+		statusContent := StatusFileContent{}
+
+		err = json.Unmarshal(content, &statusContent)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal json: %w", err)
+		}
+
+		// Handle different status states
+		switch statusContent.Status {
+		case StatusInitializing:
+			logger.Debug("Ironic agent is initializing - waiting for readiness")
+			time.Sleep(waitingLoop)
+
+			continue
+
+		case StatusWaitingForAgent:
+			logger.Info("Ironic agent is ready, assisted installer agent can proceed")
+
+			return nil
+
+		case StatusFinalizing:
+			return errors.New("ironic agent is already finalizing")
+
+		case "":
+			logger.Debug("Ironic agent defined an empty state, waiting for readiness")
+			time.Sleep(waitingLoop)
+
+			continue
+
+		default:
+			return fmt.Errorf("unexpected ironic status: %s", statusContent.Status)
+		}
+	}
+}

--- a/src/util/status_file_test.go
+++ b/src/util/status_file_test.go
@@ -1,0 +1,161 @@
+package util
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Status File Validation", func() {
+	var (
+		tempDir             string
+		originalWaitingLoop time.Duration
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		originalWaitingLoop = waitingLoop
+		waitingLoop = 50 * time.Millisecond
+
+		tempDir, err = os.MkdirTemp("", "status_file_test")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		waitingLoop = originalWaitingLoop
+		os.RemoveAll(tempDir)
+	})
+
+	Context("when status file path is empty", func() {
+		It("should skip the check and return nil", func() {
+			err := ValidateStatusFile("")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when status file does not exist", func() {
+		It("should skip the check and return nil (feature not implemented)", func() {
+			statusFilePath := filepath.Join(tempDir, "nonexistent.json")
+			err := ValidateStatusFile(statusFilePath)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when status file is empty", func() {
+		It("should wait until status changes", func() {
+			statusFilePath := filepath.Join(tempDir, "status.json")
+
+			// Create empty file
+			Expect(os.WriteFile(statusFilePath, []byte(""), 0600)).To(Succeed())
+
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				content := StatusFileContent{Status: StatusWaitingForAgent}
+				data, err := json.Marshal(content)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(os.WriteFile(statusFilePath, data, 0600)).To(Succeed())
+			}()
+
+			err := ValidateStatusFile(statusFilePath)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when status is initializing", func() {
+		It("should wait until status changes", func() {
+			statusFilePath := filepath.Join(tempDir, "status.json")
+
+			content := StatusFileContent{Status: StatusInitializing}
+			data, _ := json.Marshal(content)
+			Expect(os.WriteFile(statusFilePath, data, 0600)).To(Succeed())
+
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				newContent := StatusFileContent{Status: StatusWaitingForAgent}
+				newData, _ := json.Marshal(newContent)
+				Expect(os.WriteFile(statusFilePath, newData, 0600)).To(Succeed())
+			}()
+
+			err := ValidateStatusFile(statusFilePath)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when status is an empty string", func() {
+		It("should wait until status changes", func() {
+			statusFilePath := filepath.Join(tempDir, "status.json")
+
+			content := StatusFileContent{Status: ""}
+			data, _ := json.Marshal(content)
+			Expect(os.WriteFile(statusFilePath, data, 0600)).To(Succeed())
+
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				newContent := StatusFileContent{Status: StatusWaitingForAgent}
+				newData, _ := json.Marshal(newContent)
+				Expect(os.WriteFile(statusFilePath, newData, 0600)).To(Succeed())
+			}()
+
+			err := ValidateStatusFile(statusFilePath)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when status is waiting for assisted agent", func() {
+		It("should return nil immediately", func() {
+			statusFilePath := filepath.Join(tempDir, "status.json")
+
+			content := StatusFileContent{Status: StatusWaitingForAgent}
+			data, _ := json.Marshal(content)
+			Expect(os.WriteFile(statusFilePath, data, 0600)).To(Succeed())
+
+			err := ValidateStatusFile(statusFilePath)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when status is finalizing", func() {
+		It("should return a finalizing status error", func() {
+			statusFilePath := filepath.Join(tempDir, "status.json")
+
+			content := StatusFileContent{Status: StatusFinalizing}
+			data, _ := json.Marshal(content)
+			Expect(os.WriteFile(statusFilePath, data, 0600)).To(Succeed())
+
+			err := ValidateStatusFile(statusFilePath)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("ironic agent is already finalizing"))
+		})
+	})
+
+	Context("when status has unexpected value", func() {
+		It("should return error with unexpected status", func() {
+			statusFilePath := filepath.Join(tempDir, "status.json")
+
+			content := StatusFileContent{Status: "unknown_status"}
+			data, _ := json.Marshal(content)
+			Expect(os.WriteFile(statusFilePath, data, 0600)).To(Succeed())
+
+			err := ValidateStatusFile(statusFilePath)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("unexpected ironic status"))
+		})
+	})
+
+	Context("when file contains invalid JSON", func() {
+		It("should return error", func() {
+			statusFilePath := filepath.Join(tempDir, "status.json")
+
+			// Write invalid JSON
+			Expect(os.WriteFile(statusFilePath, []byte("{invalid json}"), 0600)).ToNot(HaveOccurred())
+
+			err := ValidateStatusFile(statusFilePath)
+			Expect(err).ToNot(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
The check is based on a json file.
If the file is missing, the feature is considered as not implemented or that we aren't in a ABI installation ; then the check is skipped.

Assisted-by: Opencode

Following [this slack discussion](https://redhat-internal.slack.com/archives/CFP6ST0A3/p1772810746105179?thread_ts=1767898775.874839&cid=CFP6ST0A3)

Will require another PR in the ironic agent repo to actually write the file

cc @CrystalChun @dtantsur 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the ironic status file via a new command-line flag or environment variable, with a default path if neither is set.
  * The agent now validates the status file before starting and waits until the service is ready when needed.
* **Bug Fixes**
  * Improved handling of missing, empty, initializing, finalizing, and unexpected status values, including clearer error outcomes.
  * The agent terminates with a fatal error if status-file validation fails.
* **Tests**
  * Added coverage for status-file validation and readiness waiting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->