### PR TITLE
OCPBUGS-106189: Assisted installer fails to disambiguate machines

### DIFF
--- a/src/scanners/machine_uuid_scanner.go
+++ b/src/scanners/machine_uuid_scanner.go
@@ -24,6 +24,7 @@ const (
 	SerialUnspecifiedSystemString    = "unspecified system serial number"     // BF cards
 	SerialNotSpecified               = "not specified"                        // Linode
 	SerialProliantGen11              = "PCA_number.ACC"                       // Proliant Gen 11
+	SerialOemDefault                 = "To be filled by O.E.M."               // Generic BIOS placeholder
 	ZeroesUUID                       = "00000000-0000-0000-0000-000000000000"
 	KaloomUUID                       = "03000200-0400-0500-0006-000700080009" // All hosts of this type have the same UUID
 )
@@ -34,7 +35,8 @@ var (
 
 var unknownSerialCases = []string{"", util.UNKNOWN, "none", "(none)", "-",
 	SerialUnspecifiedBaseBoardString, SerialUnspecifiedSystemString,
-	SerialDefaultString, SerialNotSpecified, strings.ToLower(SerialProliantGen11)}
+	SerialDefaultString, SerialNotSpecified, strings.ToLower(SerialProliantGen11),
+	strings.ToLower(SerialOemDefault)}
 var unknownUuidCases = []string{"", util.UNKNOWN, ZeroesUUID, KaloomUUID}
 
 func disableGHWWarnings() {

--- a/src/scanners/machine_uuid_scanner_test.go
+++ b/src/scanners/machine_uuid_scanner_test.go
@@ -77,6 +77,12 @@ var _ = Describe("Machine uuid test", func() {
 		id := ReadId(serialDiscovery, dependencies)
 		Expect(id).To(Equal(toUUID(TestUuid)))
 	})
+	It("OEM default serial", func() {
+		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: SerialOemDefault}, nil).Once()
+		serialDiscovery.On("Product").Return(&ghw.ProductInfo{UUID: TestUuid}, nil)
+		id := ReadId(serialDiscovery, dependencies)
+		Expect(id).To(Equal(toUUID(TestUuid)))
+	})
 	It("dash serial embedded", func() {
 		serialDiscovery.On("Baseboard").Return(&ghw.BaseboardInfo{SerialNumber: "123-456-789"}, nil).Once()
 		id := ReadId(serialDiscovery, dependencies)
@@ -89,6 +95,7 @@ var _ = Describe("Machine uuid test", func() {
 		uuid     string
 	}{
 		{useCase: "kaloom", mbSerial: SerialDefaultString, uuid: KaloomUUID},
+		{useCase: "oem-placeholder", mbSerial: SerialOemDefault, uuid: KaloomUUID},
 		{useCase: "proliantgen11", mbSerial: SerialProliantGen11, uuid: ZeroesUUID},
 		{useCase: "zeroes", mbSerial: SerialDefaultString, uuid: ZeroesUUID},
 		{useCase: "linode", mbSerial: SerialNotSpecified, uuid: "Not Settable"},


### PR DESCRIPTION
Assisted Installer treated To be filled by O.E.M. as a valid motherboard serial, causing multiple machines to generate the same host ID. This change ignores the placeholder and falls back to the system UUID or network interface MAC address, with regression coverage added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Motherboard serial numbers containing the default OEM placeholder are no longer treated as valid hardware identifiers.
  - Systems with this placeholder now use the product UUID or MAC address fallback for machine identification.

- **Tests**
  - Added coverage for OEM placeholder serial handling, including product UUID selection and MAC address fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->